### PR TITLE
feat(apps/sveltekit-example-app): use example-pkg

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -13,6 +13,9 @@
     "preview": "vite preview",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@packages/example-pkg": "workspace:*"
+  },
   "devDependencies": {
     "@sveltejs/adapter-auto": "3.1.1",
     "@sveltejs/kit": "2.5.0",

--- a/apps/sveltekit-example-app/src/routes/+page.svelte
+++ b/apps/sveltekit-example-app/src/routes/+page.svelte
@@ -1,2 +1,13 @@
+<script lang="ts">
+  import { greetUser } from '@packages/example-pkg'
+
+  import type { PageData } from './$types'
+
+  export let data: PageData
+
+  $: greeting = greetUser(data.user)
+</script>
+
 <h1>Welcome to SvelteKit</h1>
 <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<p>{greeting}</p>

--- a/apps/sveltekit-example-app/src/routes/+page.ts
+++ b/apps/sveltekit-example-app/src/routes/+page.ts
@@ -1,0 +1,13 @@
+import type { PageLoad } from './$types'
+import type { User } from '@packages/example-pkg'
+
+export const load = ((): { user: User } => {
+  return {
+    user: {
+      first_name: 'Bob',
+      last_name: 'Loblaw',
+      email: 'bob@loblaw.com',
+      is_admin: true,
+    },
+  }
+}) satisfies PageLoad

--- a/packages/example-pkg/package.json
+++ b/packages/example-pkg/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "type": "module",
   "exports": {
-    "./subtract": "./src/index.ts"
+    ".": "./src/index.ts"
   },
   "scripts": {
     "clean": "del .turbo dist coverage",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,10 @@ importers:
         version: 1.12.4
 
   apps/sveltekit-example-app:
+    dependencies:
+      '@packages/example-pkg':
+        specifier: workspace:*
+        version: link:../../packages/example-pkg
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: 3.1.1


### PR DESCRIPTION
Use the interface and utility function in example-pkg to build out a SvelteKit PageLoad for the default route.