### PR TITLE
fix(turborepo): task dependencies not working as expected

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,12 @@
     "clean": {
       "cache": false
     },
-    "codegen": {},
+    "topo": {
+      "dependsOn": ["^topo"]
+    },
+    "codegen": {
+      "dependsOn": ["topo"]
+    },
     "lint": {
       "dependsOn": ["codegen"]
     },


### PR DESCRIPTION
* All tasks run in parallel to keep things speedy: 
** Because the results of your type checks don't depend on each other, you can run all of them in parallel.
* Change in a dependency should result in a cache miss: 
**  If package 'A' changes, the task in dependent packages should know to miss cache.

see:
turbo.build/repo/docs/core-concepts/monorepos/task-dependencies#dependencies-outside-of-a-task