### PR TITLE
fix(toolchain/eslint-config): more specific include for vitest files

### DIFF
--- a/toolchain/eslint-config/configs/vitest.js
+++ b/toolchain/eslint-config/configs/vitest.js
@@ -9,7 +9,7 @@ import plugin from 'eslint-plugin-vitest'
  */
 export default defineFlatConfig([
   {
-    files: ['**/*.test.ts', '**/*.spec.ts'],
+    files: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
     plugins: {
       vitest: plugin,
     },


### PR DESCRIPTION
Limit linting of vitest files to only *.test.ts files in the src folder.