### PR TITLE
refactor(packages/vitest-config): re-export defineconfig and mergeconfig

### DIFF
--- a/apps/sveltekit-example-app/vite.config.js
+++ b/apps/sveltekit-example-app/vite.config.js
@@ -1,6 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite'
-// eslint-disable-next-line import/no-extraneous-dependencies -- (as designed, vite is hoisted and available globally)
-import { defineConfig, mergeConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vite'
 
 import vitestSharedConfig from '@toolchain/vitest-config'
 

--- a/packages/drizzledb-pg/vitest.config.js
+++ b/packages/drizzledb-pg/vitest.config.js
@@ -1,7 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- (as designed, vite is hoisted and available globally)
-import { defineConfig, mergeConfig } from 'vitest/config'
-
-import sharedConfig from '@toolchain/vitest-config'
+import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
 import packageJson from './package.json'
 

--- a/packages/example-pkg/vitest.config.js
+++ b/packages/example-pkg/vitest.config.js
@@ -1,7 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- (as designed, vite is hoisted and available globally)
-import { defineConfig, mergeConfig } from 'vitest/config'
-
-import sharedConfig from '@toolchain/vitest-config'
+import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
 import packageJson from './package.json'
 

--- a/toolchain/vitest-config/index.d.ts
+++ b/toolchain/vitest-config/index.d.ts
@@ -1,1 +1,3 @@
-declare module '@toolchain/vitest-config' {}
+declare module '@toolchain/vitest-config' {
+  export { defineConfig, mergeConfig } from 'vitest/config'
+}

--- a/toolchain/vitest-config/index.js
+++ b/toolchain/vitest-config/index.js
@@ -14,3 +14,5 @@ export default defineConfig({
     },
   },
 })
+
+export { defineConfig, mergeConfig } from 'vitest/config'


### PR DESCRIPTION
Vitest is hoisted to the global npm space to alleviate the need to have to import vitest and other related dependencies in each and every workspace package. But the config in the workspaces needs to import
defineConfig and mergeConfig from vitest and there is an ESLint rule to prevent imports of deps not present in the workspaces package.json. So this refactor simply re-exports defineConfig and mergeConfig out of
@toolchain/vitest-config.