### PR TITLE
fix(toolchain/eslint-config): remove config from import/order rule

### DIFF
--- a/toolchain/eslint-config/configs/js/import.js
+++ b/toolchain/eslint-config/configs/js/import.js
@@ -100,7 +100,6 @@ export default defineFlatConfig({
       {
         groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object', 'type'],
         'newlines-between': 'always',
-        pathGroupsExcludedImportTypes: ['internal'],
         alphabetize: {
           order: 'asc',
           orderImportKind: 'asc',


### PR DESCRIPTION
`pathGroupsExcludedImportTypes` was determined to not be needed as this config uses the setting
`import/internal-regex` and not pathGroups