### PR TITLE
fix(apps/sveltekit-example-app): bundling issue with oslo and vite build

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -16,11 +16,12 @@
     "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@packages/auth-lucia": "workspace:*",
-    "@packages/example-pkg": "workspace:*",
-    "@packages/ui-svelte": "workspace:*"
+    "oslo": "1.2.0"
   },
   "devDependencies": {
+    "@packages/auth-lucia": "workspace:*",
+    "@packages/example-pkg": "workspace:*",
+    "@packages/ui-svelte": "workspace:*",
     "@sveltejs/adapter-auto": "3.2.0",
     "@sveltejs/kit": "2.5.6",
     "@sveltejs/vite-plugin-svelte": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,10 @@ importers:
 
   apps/sveltekit-example-app:
     dependencies:
+      oslo:
+        specifier: 1.2.0
+        version: 1.2.0
+    devDependencies:
       '@packages/auth-lucia':
         specifier: workspace:*
         version: link:../../packages/auth-lucia
@@ -50,7 +54,6 @@ importers:
       '@packages/ui-svelte':
         specifier: workspace:*
         version: link:../../packages/ui-svelte
-    devDependencies:
       '@sveltejs/adapter-auto':
         specifier: 3.2.0
         version: 3.2.0(@sveltejs/kit@2.5.6(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.9(@types/node@20.12.7)))(svelte@4.2.15)(vite@5.2.9(@types/node@20.12.7)))


### PR DESCRIPTION
when running `vite build` was getting the following error:
```
vite v5.2.9 building SSR bundle for production...
✓ 549 modules transformed.
x Build failed in 5.75s
error during build:
RollupError: Unexpected character '�'
```

Even though oslo is being brought in as a dependency in @packages/auth-lucia it was still trying to be bundled by svelte as `oslo` was not physically present in the SvelteKit app's package.json as a dependency.