### PR TITLE
fix(apps/sveltekit-example-app): resolve issue with tailwindcss and intellisense

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -25,7 +25,6 @@
     "@sveltejs/adapter-auto": "3.2.0",
     "@sveltejs/kit": "2.5.6",
     "@sveltejs/vite-plugin-svelte": "3.1.0",
-    "@tailwindcss/forms": "0.5.7",
     "@toolchain/eslint-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
     "autoprefixer": "10.4.19",

--- a/apps/sveltekit-example-app/postcss.config.js
+++ b/apps/sveltekit-example-app/postcss.config.js
@@ -1,11 +1,9 @@
-import autoprefixer from 'autoprefixer'
-import tailwindcss from 'tailwindcss'
-
-import tailwindConfig from './tailwind.config.js'
-
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: [tailwindcss(tailwindConfig), autoprefixer],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }
 
 export default config

--- a/apps/sveltekit-example-app/tailwind.config.js
+++ b/apps/sveltekit-example-app/tailwind.config.js
@@ -1,21 +1,12 @@
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-import forms from '@tailwindcss/forms'
-
 import sharedConfig from '@packages/ui-svelte/tailwind.config.js'
 
 /** @type {import('tailwindcss').Config} */
 const config = {
   content: [
-    './src/**/*.{html,js,svelte,ts}',
-    join(
-      fileURLToPath(import.meta.resolve('@packages/ui-svelte/tailwind.config.js')),
-      '../**/*.{html,js,svelte,ts}',
-    ),
+    './src/**/*.{html,svelte,ts}',
+    './../../packages/ui-svelte/src/components/**/*.{svelte,ts}',
   ],
   presets: [sharedConfig],
-  plugins: [forms],
 }
 
 export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: 3.1.0
         version: 3.1.0(svelte@4.2.15)(vite@5.2.9(@types/node@20.12.7))
-      '@tailwindcss/forms':
-        specifier: 0.5.7
-        version: 0.5.7(tailwindcss@3.4.3)
       '@toolchain/eslint-config':
         specifier: workspace:*
         version: link:../../toolchain/eslint-config
@@ -1528,11 +1525,6 @@ packages:
 
   '@swc/helpers@0.5.10':
     resolution: {integrity: sha512-CU+RF9FySljn7HVSkkjiB84hWkvTaI3rtLvF433+jRSBL2hMu3zX5bGhHS8C80SM++h4xy8hBSnUHFQHmRXSBw==}
-
-  '@tailwindcss/forms@0.5.7':
-    resolution: {integrity: sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -3520,10 +3512,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  mini-svg-data-uri@1.4.4:
-    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
-    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -6035,11 +6023,6 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@tailwindcss/forms@0.5.7(tailwindcss@3.4.3)':
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.3
-
   '@tootallnate/once@2.0.0': {}
 
   '@tybys/wasm-util@0.8.1':
@@ -8356,8 +8339,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   min-indent@1.0.1: {}
-
-  mini-svg-data-uri@1.4.4: {}
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
Trying to resolve the location of the @packages/ui-svelte using import.meta.resolve caused issues with the ide detecting 
tailwind config and not enabling intellisense for tailwind utility class auto-completion.