### PR TITLE
refactor(turborepo): rework turbo tasks and task dependencies

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -5,13 +5,10 @@
   "description": "SvelteKit Example App",
   "type": "module",
   "scripts": {
-    "build": "vite build",
-    "check": "pnpm run code-gen && pnpm run type-check",
+    "build": "svelte-kit sync",
     "clean": "del .turbo coverage .svelte-kit .vercel",
-    "codegen": "svelte-kit sync",
     "dev": "vite dev",
     "lint": "eslint .",
-    "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },

--- a/apps/sveltekit-example-app/turbo.json
+++ b/apps/sveltekit-example-app/turbo.json
@@ -2,9 +2,6 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "outputs": [".svelte-kit/**", ".vercel/**"]
-    },
-    "codegen": {
       "outputs": [".svelte-kit/**"]
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "turbo run build",
     "clean": "turbo run clean",
     "format": "prettier --write .",
     "lint": "turbo run lint",

--- a/packages/ui-svelte/package.json
+++ b/packages/ui-svelte/package.json
@@ -13,9 +13,11 @@
     "./tailwind.config.js": "./tailwind.config.js"
   },
   "scripts": {
-    "story:build": "histoire build",
-    "story:dev": "histoire dev",
-    "story:preview": "histoire preview"
+    "clean": "del .turbo coverage",
+    "dev": "histoire dev",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
     "bits-ui": "0.21.4",
@@ -37,6 +39,7 @@
     "histoire": "0.17.17",
     "postcss": "8.4.38",
     "postcss-load-config": "5.0.3",
+    "svelte-check": "3.6.9",
     "tailwindcss": "3.4.3",
     "vite": "5.2.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       postcss-load-config:
         specifier: 5.0.3
         version: 5.0.3(jiti@1.21.0)(postcss@8.4.38)
+      svelte-check:
+        specifier: 3.6.9
+        version: 3.6.9(postcss-load-config@5.0.3(jiti@1.21.0)(postcss@8.4.38))(postcss@8.4.38)(svelte@4.2.15)
       tailwindcss:
         specifier: 3.4.3
         version: 3.4.3

--- a/turbo.json
+++ b/turbo.json
@@ -7,20 +7,16 @@
     "clean": {
       "cache": false
     },
-    "topo": {
-      "dependsOn": ["^topo"]
-    },
-    "codegen": {
-      "dependsOn": ["topo"]
-    },
     "lint": {
-      "dependsOn": ["codegen"]
+      "dependsOn": ["build"]
     },
     "test": {
+      "dependsOn": ["build"],
+      "inputs": ["./src/**/*.ts", "./src/**/*.svelte"],
       "outputs": ["./coverage/**"]
     },
     "typecheck": {
-      "dependsOn": ["codegen"]
+      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
* core scripts now consist of build,clean,dev,lint,test,typecheck.
* build must run in dependencies before this package's build can run
* lint,test, and typecheck now depended on its respective build to run first
* eliminated the need for the artificial `topo` task