### PR TITLE
feat(toolchain/typescript-config): all projects now extend from one of the provided profiles

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -23,6 +23,7 @@
     "@sveltejs/kit": "2.5.6",
     "@sveltejs/vite-plugin-svelte": "3.1.0",
     "@toolchain/eslint-config": "workspace:*",
+    "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
     "autoprefixer": "10.4.19",
     "postcss": "8.4.38",

--- a/apps/sveltekit-example-app/src/routes/sign-up/+page.server.ts
+++ b/apps/sveltekit-example-app/src/routes/sign-up/+page.server.ts
@@ -31,11 +31,14 @@ export const actions = {
           ...sessionCookie.attributes,
         })
         return message(form, 'Form posted successfully!')
+      } else {
+        return message(form, 'User was not returned!')
       }
     } catch (err) {
       if (err instanceof Error) {
         return setError(form, 'email', 'E-mail already exists.')
       }
+      throw err
     }
   },
 } satisfies Actions

--- a/apps/sveltekit-example-app/svelte.config.js
+++ b/apps/sveltekit-example-app/svelte.config.js
@@ -13,6 +13,12 @@ const config = {
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
     alias: {},
+    typescript: {
+      config: (config) => {
+        config['extends'] = './.././node_modules/@toolchain/typescript-config/tsconfig-svelte.json'
+        return config
+      },
+    },
   },
 }
 

--- a/apps/sveltekit-example-app/tsconfig.json
+++ b/apps/sveltekit-example-app/tsconfig.json
@@ -1,19 +1,6 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "allowJs": true,
-    "checkJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "moduleResolution": "bundler",
     "types": ["vitest/globals"]
   }
-  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-  //
-  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-  // from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/packages/auth-lucia/src/repository/index.ts
+++ b/packages/auth-lucia/src/repository/index.ts
@@ -19,12 +19,6 @@ export const findByUsername = async (username: string): Promise<User | undefined
 export const createUser = async (user: NewUser): Promise<string | undefined> => {
   const hashedPassword = await new Argon2id().hash(user.password)
 
-  await db.query.users.findMany({
-    with: {
-      sessions: true,
-    },
-  })
-
   return db
     .insert(users)
     .values({ username: user.username, hashedPassword })

--- a/packages/auth-lucia/tsconfig.json
+++ b/packages/auth-lucia/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-base.json",
+  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-node20.json",
   "compilerOptions": {
     "types": ["vitest/globals"]
   }

--- a/packages/db-drizzlepg/tsconfig.json
+++ b/packages/db-drizzlepg/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-base.json",
+  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-node20.json",
   "compilerOptions": {
     "types": ["vitest/globals"]
   }

--- a/packages/example-pkg/tsconfig.json
+++ b/packages/example-pkg/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-base.json",
+  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-node20.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"]
   }

--- a/packages/ui-svelte/tsconfig.json
+++ b/packages/ui-svelte/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-base.json",
+  "extends": "./node_modules/@toolchain/typescript-config/tsconfig-svelte.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "exactOptionalPropertyTypes": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["vitest/globals"]
-  },
-  "include": ["src/**/*.ts", "src/**/*.svelte"]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@toolchain/eslint-config':
         specifier: workspace:*
         version: link:../../toolchain/eslint-config
+      '@toolchain/typescript-config':
+        specifier: workspace:*
+        version: link:../../toolchain/typescript-config
       '@toolchain/vitest-config':
         specifier: workspace:*
         version: link:../../toolchain/vitest-config

--- a/toolchain/typescript-config/base/tsconfig-base.json
+++ b/toolchain/typescript-config/base/tsconfig-base.json
@@ -56,6 +56,5 @@
     /* Completeness */
     "skipLibCheck": true,                             /* Skip type checking all .d.ts files. */
   },
-  "include": ["../../../src/**/*.ts"],
   "exclude": ["../../../node_modules"]
 }

--- a/toolchain/typescript-config/base/tsconfig-base.json
+++ b/toolchain/typescript-config/base/tsconfig-base.json
@@ -1,7 +1,7 @@
 // prettier-ignore
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Node 20 + ESM + Strictest",
+  "display": "Base TypeScript Configuration",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -11,16 +11,10 @@
     "disableSourceOfProjectReferenceRedirect": false, /* Disable preferring source files instead of declaration files when referencing composite projects */
 
     /* Language and Environment */
-    "target": "ES2022",                               /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": [
-      "ES2023"
-    ],                                                /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 
     /* Modules */
-    "module": "NodeNext",                             /* Specify what module code is generated. */
-    "moduleResolution": "NodeNext",                   /* Specify how TypeScript looks up a file from a given module specifier. */
     "resolveJsonModule": true,                        /* Enable importing .json files */
 
     /* Emit */
@@ -33,11 +27,13 @@
     "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
 
     /* Interop Constraints */
+    "isolatedModules": false,                         /* Ensure that each file can be safely transpiled without relying on other imports. */
     "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     "esModuleInterop": true,                          /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
+    "strict": true,                                   /* Enable all strict type-checking options. */
     "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */

--- a/toolchain/typescript-config/package.json
+++ b/toolchain/typescript-config/package.json
@@ -6,7 +6,8 @@
   "license": "UNLICENSED",
   "type": "module",
   "files": [
-    "tsconfig-base.json"
+    "tsconfig-node20.json",
+    "tsconfig-svelte.json"
   ],
   "dependencies": {
     "typescript": "5.4.5"

--- a/toolchain/typescript-config/tsconfig-node20.json
+++ b/toolchain/typescript-config/tsconfig-node20.json
@@ -16,4 +16,5 @@
     "module": "NodeNext",                             /* Specify what module code is generated. */
     "moduleResolution": "NodeNext"                   /* Specify how TypeScript looks up a file from a given module specifier. */
   },
+  "include": ["../../../src/**/*.ts"]
 }

--- a/toolchain/typescript-config/tsconfig-node20.json
+++ b/toolchain/typescript-config/tsconfig-node20.json
@@ -1,0 +1,19 @@
+// prettier-ignore
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 20 + ESM + Strictest",
+  "extends": "./base/tsconfig-base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Language and Environment */
+    "target": "ES2022",                               /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "ES2023"
+    ],                                                /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+
+    /* Modules */
+    "module": "NodeNext",                             /* Specify what module code is generated. */
+    "moduleResolution": "NodeNext"                   /* Specify how TypeScript looks up a file from a given module specifier. */
+  },
+}

--- a/toolchain/typescript-config/tsconfig-svelte.json
+++ b/toolchain/typescript-config/tsconfig-svelte.json
@@ -1,0 +1,25 @@
+// prettier-ignore
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 20 + ESM + Strictest",
+  "extends": "./base/tsconfig-base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Language and Environment */
+    "target": "ESNext",                               /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],                                                /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+
+    /* Modules */
+    "module": "ESNext",                               /* Specify what module code is generated. */
+    "moduleResolution": "Bundler",                    /* Specify how TypeScript looks up a file from a given module specifier. */
+
+    /* Type Checking */
+    "exactOptionalPropertyTypes": false              /* Interpret optional property types as written, rather than adding 'undefined'. */
+  },
+  "include": ["../../../src/**/*.ts", "../../../src/**/*.svelte"],
+}


### PR DESCRIPTION
* added two profiles, one for node20 and the other for svelte
* updated all projects to use one or the other profile
* updated svelte.config.js to modify generated tsconfig.json to extend shared config