### PR TITLE
refactor(monorepo): change how citext extension is added without custom image

### DIFF
--- a/.docker/init.sql
+++ b/.docker/init.sql
@@ -1,0 +1,7 @@
+SET search_path TO public;
+
+-- Extension Creations
+
+CREATE EXTENSION IF NOT EXISTS citext SCHEMA public;
+
+select * FROM pg_extension;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - '5432:5432'
     volumes:
       - ./.docker/data/pg-data:/var/lib/postgresql/data
+      - ./.docker/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   mailpit:
     image: axllent/mailpit


### PR DESCRIPTION
update docker-compose file to not need custom image to auto-install `citext` extension