### PR TITLE
fix(packages/ui-lib-svelte): use correct plugin for sveltekit

### DIFF
--- a/packages/ui-lib-svelte/vite.config.ts
+++ b/packages/ui-lib-svelte/vite.config.ts
@@ -1,4 +1,4 @@
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig, mergeConfig } from 'vite'
 
 import vitestSharedConfig from '@toolchain/vitest-config'
@@ -8,7 +8,7 @@ import packageJson from './package.json'
 export default mergeConfig(
   vitestSharedConfig,
   defineConfig({
-    plugins: [svelte()],
+    plugins: [sveltekit()],
     test: {
       name: packageJson.name,
     },


### PR DESCRIPTION
This was a copy/paste issue when replacing the previous ui library based on svelte.