### PR TITLE
feat(toolchain/eslint-config): enable experimental generics flag in svelte parser

### DIFF
--- a/toolchain/eslint-config/configs/svelte.js
+++ b/toolchain/eslint-config/configs/svelte.js
@@ -27,6 +27,9 @@ export default defineFlatConfig([
         parser: typescriptParser,
         projectService: true,
         extraFileExtensions: ['.svelte'],
+        svelteFeatures: {
+          experimentalGenerics: true,
+        },
       },
     },
     processor: 'svelte/svelte',


### PR DESCRIPTION
When enabled it will parse the `generics` attribute, as a result eslint now sees the var in the generics attr

see https://github.com/sveltejs/svelte-eslint-parser?tab=readme-ov-file#parseroptionssveltefeatures