### PR TITLE
refactor(apps/sveltekit-example-app): docker file improvement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 .git
+.github
 .gitignore
 node_modules
+
+.husky
+.turbo
 
 .svelte-kit
 build

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pnpm run -w typecheck
 docker build . -t sveltekit-example-app
 ```
 ```shell
-docker run --rm --name=sveltekit-example-app -p 8080:8080 sveltekit-example-app
+docker run --rm --name=sveltekit-example-app -p 8080:3000 sveltekit-example-app
 ```
 
 ## Conventional Commits Best Practices

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "packageManager": "pnpm@9.6.0+sha256.dae0f7e822c56b20979bb5965e3b73b8bdabb6b8b8ef121da6d857508599ca35",
   "engines": {
-    "node": "20.11.x"
+    "node": ">= 20.11.x < 21.x.x"
   }
 }


### PR DESCRIPTION
* use turborepo to only build SvelteKit app and its dependencies.]
* add more exclusions in .dockerignore
* unrelated fix to package.json engines:node to accommodate newer point releases