### PR TITLE
fix(monorepo): use pnpm cache in github actions

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -5,14 +5,15 @@ runs:
   using: composite
   steps:
     - name: Install pnpm package manager
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v4
 
     - name: Setup Node.js environment
       uses: actions/setup-node@v4
       with:
-        node-version-file: 'package.json'
+        node-version-file: package.json
         cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --ignore-scripts
+      run: pnpm install --ignore-scripts --frozen-lockfile


### PR DESCRIPTION
update pnpm/action-setup to v4 as well