### PR TITLE
feat(dockerfile): optimize build step of app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
 
-RUN pnpm exec turbo build --filter=@apps/$APP_NAME...
+RUN pnpm exec turbo build --filter=@apps/$APP_NAME^...
 
 RUN pnpm --filter=@apps/$APP_NAME exec vite build
 RUN pnpm --filter=@apps/$APP_NAME deploy --prod out


### PR DESCRIPTION
Use the TurboRepo --filter option `^...` to
build only the Dockerized app's dependents,
if any. No reason to run `build` on the Dockerized app as that will be built for real during the `vite build`.  Recall that the package.json build script only runs svelte-check.

Resolves #127