### PR TITLE
fix(packages/db-drizzlepg): .env files are not loading into process.env

### DIFF
--- a/packages/db-drizzlepg/src/client/env-config.ts
+++ b/packages/db-drizzlepg/src/client/env-config.ts
@@ -14,4 +14,6 @@ const envSchema = z.object({
   DB_MAX_CONNECTIONS: z.coerce.number().min(1).default(10),
 })
 
-export default envSchema.parse(dotenv.config().parsed)
+dotenv.config()
+
+export default envSchema.parse(process.env)


### PR DESCRIPTION
Misunderstood how/what the config.parsed did. This was causing the dotenv to not load in process.env.

Resolves #126