### PR TITLE
fix(packages/api): return the token via the signup call

### DIFF
--- a/apps/sveltekit-example-app/src/lib/server/api-client-handler.ts
+++ b/apps/sveltekit-example-app/src/lib/server/api-client-handler.ts
@@ -7,6 +7,7 @@ export const apiClientHandler: Handle = ({ event, resolve }) => {
   const { api } = apiClient('/', {
     fetch: event.fetch,
     headers: {
+      // TODO: Set access token here from cookie value
       host: event.request.headers.get('host') ?? '',
       'x-forwarded-for': event.getClientAddress(),
     },

--- a/packages/api/src/controllers/accounts.controller.ts
+++ b/packages/api/src/controllers/accounts.controller.ts
@@ -1,6 +1,5 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
-import { setCookie } from 'hono/cookie'
 import { z } from 'zod'
 
 import { lucia } from '@packages/auth-lucia'
@@ -30,15 +29,14 @@ const app = new Hono<HonoTypes>()
       const userId = await createUser({ password, username })
       if (userId) {
         const session = await lucia.createSession(userId, {})
-        const sessionCookie = lucia.createSessionCookie(session.id)
-        setCookie(c, sessionCookie.name, sessionCookie.value, {
-          path: '.',
-          ...sessionCookie.attributes,
+        console.log('**  ', session.expiresAt)
+        return c.json({
+          accessToken: session,
+          message: `Verification email sent to ${username}`,
         })
       }
-      return c.json({
-        message: `Verification email sent to ${username}`,
-      })
+      c.status(400)
+      return c.text('createUser failed')
     } catch (error) {
       if (error instanceof Error) {
         c.status(400)

--- a/packages/api/src/middlewares/auth.middleware.ts
+++ b/packages/api/src/middlewares/auth.middleware.ts
@@ -17,6 +17,8 @@ type ValidatedAuthSession =
       user: User
     }
 
+const AUTHORIZATION = 'Authorization'
+
 export const validateAuthSession: MiddlewareHandler<HonoTypes> = createMiddleware(
   async (c, next) => {
     let validatedAuthSession: ValidatedAuthSession = {
@@ -24,13 +26,21 @@ export const validateAuthSession: MiddlewareHandler<HonoTypes> = createMiddlewar
       user: null,
     }
 
-    const sessionId = getCookie(c, lucia.sessionCookieName)
+    // Get the token from a cookie for non-API requests
+    const cookie_token = getCookie(c, lucia.sessionCookieName)
 
-    if (sessionId) {
-      validatedAuthSession = await lucia.validateSession(sessionId)
+    // Get the token from the 'Authorization: Bearer <token>' header for API requests
+    const bearer_token = c.req.header(AUTHORIZATION)?.split(' ')[1]
+
+    const access_token = cookie_token ?? bearer_token
+
+    if (access_token) {
+      validatedAuthSession = await lucia.validateSession(access_token)
 
       const { session } = validatedAuthSession
 
+      // TODO: Need to implement the ability to refresh/extend access tokens when
+      //       api is not running in the SvelteKit context
       if (session?.fresh) {
         // Session expiration needs to be extended, create a new session cookie
         const { attributes, name, value } = lucia.createSessionCookie(session.id)
@@ -38,6 +48,8 @@ export const validateAuthSession: MiddlewareHandler<HonoTypes> = createMiddlewar
       }
 
       if (!session) {
+        // TODO: Need to implement the ability to invalidate access tokens when
+        //       api is not running in the SvelteKit context
         // Session is invalid, invalidate existing session cookie
         const { attributes, name, value } = lucia.createBlankSessionCookie()
         setCookie(c, name, value, { path: '.', ...attributes })


### PR DESCRIPTION
Setting the Cookie in the API doesn't
work when the API is running outside the
web application.

Should not set cookies in the API layer as
it is a higher-order concern. So just
return the token from the API call and let
the upstream caller decide what to do with
it.