### PR TITLE
feat(toolchain/eslint-config): update js prefer-const rule

### DIFF
--- a/toolchain/eslint-config/configs/javascript.js
+++ b/toolchain/eslint-config/configs/javascript.js
@@ -45,6 +45,8 @@ export default defineFlatConfig([
       'prefer-arrow-callback': 'error',
 
       'no-duplicate-imports': 'error',
+
+      'prefer-const': ['error', { destructuring: 'all' }],
     },
   },
   importConfig,


### PR DESCRIPTION
for destructured variables the default to
error is 'any' variables in destructuring
should be const. Changed to 'all', so now
all variables in destructuring should be
const