### PR TITLE
fix(toolchain/eslint-config): svelte attr sorting

### DIFF
--- a/apps/sveltekit-example-app/src/routes/account/sign-up/+page.svelte
+++ b/apps/sveltekit-example-app/src/routes/account/sign-up/+page.svelte
@@ -23,11 +23,11 @@
         <label class="block" for="username">Email</label>
         <div class="mt-2">
           <input
-            aria-invalid={$errors.username ? 'true' : undefined}
-            bind:value={$formData.username}
-            data-invalid={$errors.username ? 'true' : undefined}
             name="username"
+            aria-invalid={$errors.username ? 'true' : undefined}
+            data-invalid={$errors.username ? 'true' : undefined}
             type="email"
+            bind:value={$formData.username}
             {...$constraints.username}
             class="block w-full border py-1.5" />
 
@@ -38,11 +38,11 @@
         <label class="block" for="password">Password</label>
         <div class="mt-2">
           <input
-            aria-invalid={$errors.password ? 'true' : undefined}
-            bind:value={$formData.password}
-            data-invalid={$errors.password ? 'true' : undefined}
             name="password"
+            aria-invalid={$errors.password ? 'true' : undefined}
+            data-invalid={$errors.password ? 'true' : undefined}
             type="password"
+            bind:value={$formData.password}
             {...$constraints.password}
             class="block w-full border py-1.5" />
           {#if $errors.password}<span class="text-red-500">{$errors.password}</span>{/if}
@@ -52,11 +52,11 @@
         <label for="password_confirm">Confirm Password</label>
         <div class="mt-2">
           <input
-            aria-invalid={$errors.password_confirm ? 'true' : undefined}
-            bind:value={$formData.password_confirm}
-            data-invalid={$errors.password_confirm ? 'true' : undefined}
             name="password_confirm"
+            aria-invalid={$errors.password_confirm ? 'true' : undefined}
+            data-invalid={$errors.password_confirm ? 'true' : undefined}
             type="password"
+            bind:value={$formData.password_confirm}
             {...$constraints.password_confirm}
             class="block w-full border py-1.5" />
           {#if $errors.password_confirm}<span class="text-red-500">{$errors.password_confirm}</span

--- a/toolchain/eslint-config/configs/js/perfectionist.js
+++ b/toolchain/eslint-config/configs/js/perfectionist.js
@@ -166,16 +166,6 @@ export default defineFlatConfig({
         type: sortingMethodType,
       },
     ],
-    'perfectionist/sort-svelte-attributes': [
-      'error',
-      {
-        customGroups: {},
-        groups: [],
-        ignoreCase: true,
-        order: 'asc',
-        type: sortingMethodType,
-      },
-    ],
     'perfectionist/sort-switch-case': [
       'error',
       {

--- a/toolchain/eslint-config/configs/svelte.js
+++ b/toolchain/eslint-config/configs/svelte.js
@@ -46,11 +46,7 @@ export default defineFlatConfig([
       ...plugin.configs.base.overrides[0].rules,
       ...plugin.configs.recommended.rules,
 
-      /**
-       * Turn off this rule as attributes in svelte components
-       * are sorted with Perfectionist
-       */
-      'svelte/sort-attributes': 'off',
+      'svelte/sort-attributes': 'error',
 
       'svelte/block-lang': ['error', { script: 'ts', style: ['postcss', 'css'] }],
 


### PR DESCRIPTION
Was using perfectionist's eslint rule to
sort svelte attributes but this was causing
conflicts with prettier svelte plugin. Could
not disable sorting in prettier so decided
to revert back to the sorting rules in
svelte's eslint plugin which doesn't seem to
conflict with svelte's prettier sorting.

This was an example of the issue inside a svelte component: 
`<svelte:element  class="foo" this={undefined} />`