### PR TITLE
refactor(monorepo): change name of composite action

### DIFF
--- a/.github/composite-actions/prepare/action.yml
+++ b/.github/composite-actions/prepare/action.yml
@@ -1,5 +1,5 @@
-name: 'Install'
-description: 'Sets up Node, and installs dependencies'
+name: Prepare
+description: Prepares the repo for a typical CI job
 
 runs:
   using: composite

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,48 +2,48 @@ name: code-quality
 on:
   push:
     branches:
-      - 'main'
+      - main
   pull_request:
 
 jobs:
   lint:
-    name: 'ESLint'
+    name: ESLint
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Install
-        uses: ./.github/composite-actions/install
+      - name: Prepare
+        uses: ./.github/composite-actions/prepare
 
       - name: Run ESLint check
         run: pnpm run lint
 
   type-check:
-    name: 'Type Check'
+    name: Type Check
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Install
-        uses: ./.github/composite-actions/install
+      - name: Prepare
+        uses: ./.github/composite-actions/prepare
 
       - name: Run type checks
         run: pnpm run typecheck
 
   test:
-    name: 'Unit Test'
+    name: Unit Test
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Install
-        uses: ./.github/composite-actions/install
+      - name: Prepare
+        uses: ./.github/composite-actions/prepare
 
-      - name: Run unit test
+      - name: Run unit tests
         run: pnpm run test


### PR DESCRIPTION
Small change to update the name of the
composite action from `install` to
`prepare`. The name better reflects what the
composite action does.