### PR TITLE
refactor(toolchain/vitest): alternate approach to import package.json

### DIFF
--- a/apps/sveltekit-example-app/vite.config.js
+++ b/apps/sveltekit-example-app/vite.config.js
@@ -1,9 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite'
+import { createRequire } from 'node:module'
 import { defineConfig, mergeConfig } from 'vite'
 
 import vitestSharedConfig from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   vitestSharedConfig,

--- a/packages/api/vitest.config.js
+++ b/packages/api/vitest.config.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
 import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   sharedConfig,

--- a/packages/auth-lucia/vitest.config.js
+++ b/packages/auth-lucia/vitest.config.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
 import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   sharedConfig,

--- a/packages/db-drizzlepg/vitest.config.js
+++ b/packages/db-drizzlepg/vitest.config.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
 import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   sharedConfig,

--- a/packages/domain/vitest.config.js
+++ b/packages/domain/vitest.config.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
 import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   sharedConfig,

--- a/packages/example-pkg/vitest.config.js
+++ b/packages/example-pkg/vitest.config.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
 import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   sharedConfig,

--- a/packages/ui-lib-svelte/vite.config.js
+++ b/packages/ui-lib-svelte/vite.config.js
@@ -1,9 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite'
+import { createRequire } from 'node:module'
 import { defineConfig, mergeConfig } from 'vite'
 
 import vitestSharedConfig from '@toolchain/vitest-config'
 
-import packageJson from './package.json'
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
 
 export default mergeConfig(
   vitestSharedConfig,


### PR DESCRIPTION
Loading JSON in ESM is a bit of a mess.
This approach seems to be a good enough
working solution for now until things
mature on this feature.