### PR TITLE
feat(monorepo): add one-version, a strict dependency conformance tool for monorepos

### DIFF
--- a/.github/workflows/one-version-check.yml
+++ b/.github/workflows/one-version-check.yml
@@ -1,0 +1,18 @@
+name: One-Version Conformance Check
+on:
+  pull_request:
+
+jobs:
+  one-version-check:
+    name: One Version Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        uses: ./.github/composite-actions/prepare
+
+      - name: Run one version check
+        run: pnpm run lint

--- a/.github/workflows/one-version-check.yml
+++ b/.github/workflows/one-version-check.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Prepare
         uses: ./.github/composite-actions/prepare
 
-      - name: Run one version check
-        run: pnpm run lint
+      - name: Run One Version check
+        run: pnpm run one-version:check

--- a/.github/workflows/one-version-check.yml
+++ b/.github/workflows/one-version-check.yml
@@ -1,4 +1,4 @@
-name: One-Version Conformance Check
+name: one-version-conformance-check
 on:
   pull_request:
 

--- a/one-version.config.json
+++ b/one-version.config.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "pnpm",
+  "versionStrategy": "pin",
+  "overrides": {}
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clean": "turbo run clean",
     "format": "prettier --write .",
     "lint": "turbo run lint",
+    "one-version:check": "one-version check",
     "prepare": "husky",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck"
@@ -17,6 +18,7 @@
     "del-cli": "5.1.0",
     "husky": "9.1.6",
     "lint-staged": "15.2.10",
+    "one-version": "0.2.0",
     "prettier": "3.3.3",
     "prettier-plugin-packagejson": "2.5.2",
     "prettier-plugin-svelte": "3.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,7 +271,7 @@ importers:
         specifier: 9.11.1
         version: 9.11.1(jiti@1.21.6)
       eslint-config-prettier:
-        specifier: ^9.1.0
+        specifier: 9.1.0
         version: 9.1.0(eslint@9.11.1(jiti@1.21.6))
       eslint-import-resolver-typescript:
         specifier: 3.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       lint-staged:
         specifier: 15.2.10
         version: 15.2.10
+      one-version:
+        specifier: 0.2.0
+        version: 0.2.0
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -1888,10 +1891,6 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -2690,10 +2689,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3359,10 +3354,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
-    engines: {node: '>=8.6'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -3522,6 +3513,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  one-version@0.2.0:
+    resolution: {integrity: sha512-sKG+QUQksG06+ChFqOyoRQNi5QXpALK57V5JP14pihXE4zSHbatkKhLht+yt8Aq5DcIumP3cCjDEICvpZ9jI0A==}
+    hasBin: true
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -6082,10 +6077,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braces@3.0.2:
-    dependencies:
-      fill-range: 7.0.1
-
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -6958,7 +6949,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -6977,10 +6968,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  fill-range@7.0.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   fill-range@7.1.1:
     dependencies:
@@ -7648,11 +7635,6 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  micromatch@4.0.5:
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.3.1
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -7802,6 +7784,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  one-version@0.2.0:
+    dependencies:
+      fast-glob: 3.3.2
 
   onetime@5.1.2:
     dependencies:

--- a/toolchain/eslint-config/package.json
+++ b/toolchain/eslint-config/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "8.7.0",
     "@typescript-eslint/parser": "8.7.0",
     "eslint": "9.11.1",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-import-resolver-typescript": "3.6.3",
     "eslint-plugin-deprecation": "3.0.0",
     "eslint-plugin-eslint-comments": "3.2.0",


### PR DESCRIPTION
This tool ensures that all workspaces in
your monorepo are using the same version of
a dependency, and also enforce strict
versioning strategy to ensure that all
dependencies are pinned to an exact
version.