### PR TITLE
refactor(toolchain/eslint-config): remove v9 fixup for import and promise plugins

### DIFF
--- a/toolchain/eslint-config/configs/js/import.js
+++ b/toolchain/eslint-config/configs/js/import.js
@@ -1,4 +1,3 @@
-import { fixupPluginRules } from '@eslint/compat'
 import { defineFlatConfig } from 'eslint-define-config'
 import plugin from 'eslint-plugin-import'
 
@@ -10,7 +9,7 @@ import plugin from 'eslint-plugin-import'
  */
 export default defineFlatConfig({
   plugins: {
-    import: fixupPluginRules(plugin),
+    import: plugin,
   },
   rules: {
     ...plugin.configs.recommended.rules,

--- a/toolchain/eslint-config/configs/js/promise.js
+++ b/toolchain/eslint-config/configs/js/promise.js
@@ -1,4 +1,3 @@
-import { fixupPluginRules } from '@eslint/compat'
 import { defineFlatConfig } from 'eslint-define-config'
 import plugin from 'eslint-plugin-promise'
 
@@ -10,7 +9,7 @@ import plugin from 'eslint-plugin-promise'
  */
 export default defineFlatConfig({
   plugins: {
-    promise: fixupPluginRules(plugin),
+    promise: plugin,
   },
   rules: {
     ...plugin.configs.recommended.rules,


### PR DESCRIPTION
These two plugins have been updated to support eslint 9 and flat config.