### PR TITLE
fix(apps/sveltekit-example-app): add back vite preprocess

### DIFF
--- a/apps/sveltekit-example-app/svelte.config.js
+++ b/apps/sveltekit-example-app/svelte.config.js
@@ -1,4 +1,5 @@
 import adapter from '@sveltejs/adapter-node'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -13,6 +14,9 @@ const config = {
         return config
       },
     },
+    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+    // for more information about preprocessors
+    preprocess: vitePreprocess(),
   },
 }
 

--- a/apps/sveltekit-example-app/svelte.config.js
+++ b/apps/sveltekit-example-app/svelte.config.js
@@ -14,10 +14,10 @@ const config = {
         return config
       },
     },
-    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
-    // for more information about preprocessors
-    preprocess: vitePreprocess(),
   },
+  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
 }
 
 export default config

--- a/packages/ui-lib-svelte/svelte.config.js
+++ b/packages/ui-lib-svelte/svelte.config.js
@@ -1,4 +1,5 @@
 import adapter from '@sveltejs/adapter-auto'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -13,6 +14,9 @@ const config = {
         return config
       },
     },
+    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+    // for more information about preprocessors
+    preprocess: vitePreprocess(),
   },
 }
 

--- a/packages/ui-lib-svelte/svelte.config.js
+++ b/packages/ui-lib-svelte/svelte.config.js
@@ -14,10 +14,10 @@ const config = {
         return config
       },
     },
-    // Consult https://kit.svelte.dev/docs/integrations#preprocessors
-    // for more information about preprocessors
-    preprocess: vitePreprocess(),
   },
+  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
 }
 
 export default config


### PR DESCRIPTION
It was initially thought that
vitePreprocess was not needed with Svelte 5
but its unclear if this ever was a true
statement. Adding it back for now.