### PR TITLE
refactor(packages/db-drizzlepg): levergae optional column names in latest drizzle

### DIFF
--- a/packages/db-drizzlepg/drizzle.config.js
+++ b/packages/db-drizzlepg/drizzle.config.js
@@ -42,4 +42,9 @@ export default defineConfig({
   dbCredentials: {
     url: process.env.DB_CONNECTION_STRING,
   },
+
+  /**
+   * https://orm.drizzle.team/kit-docs/config-reference#casing
+   */
+  casing: 'snake_case',
 })

--- a/packages/db-drizzlepg/src/client/pg-client.ts
+++ b/packages/db-drizzlepg/src/client/pg-client.ts
@@ -41,6 +41,7 @@ if (DB_LOGGING_ENABLED) {
 }
 
 export const db = drizzle(connection, {
+  casing: 'snake_case',
   logger: DB_LOGGING_ENABLED ? new QueryLogger() : false,
   schema,
 })

--- a/packages/db-drizzlepg/src/schema/auth/sessions.ts
+++ b/packages/db-drizzlepg/src/schema/auth/sessions.ts
@@ -1,23 +1,19 @@
 import { relations } from 'drizzle-orm'
-import { text, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 import { namedForeignKey } from '../utils.js'
 
 import { authSchema } from './schema.js'
 import users from './users.js'
 
-const sessions = authSchema.table(
+export const sessions = authSchema.table(
   'sessions',
-  {
-    id: text('id').primaryKey(),
-    expiresAt: timestamp('expires_at', {
-      mode: 'date',
-      withTimezone: true,
-    }).notNull(),
-    userId: uuid('user_id').notNull(),
-  },
-  (table) => ({
-    fk1: namedForeignKey(table.userId, users.id),
+  (t) => ({
+    id: t.text().primaryKey(),
+    expiresAt: t.timestamp({ mode: 'date', withTimezone: true }).notNull(),
+    userId: t.uuid().notNull(),
+  }),
+  (t) => ({
+    fk1: namedForeignKey(t.userId, users.id),
   }),
 )
 

--- a/packages/db-drizzlepg/src/schema/auth/users.ts
+++ b/packages/db-drizzlepg/src/schema/auth/users.ts
@@ -1,5 +1,4 @@
 import { relations } from 'drizzle-orm'
-import { text, uuid } from 'drizzle-orm/pg-core'
 
 import { citext } from '../custom-types.js'
 import { namedUnique } from '../utils.js'
@@ -9,13 +8,13 @@ import sessions from './sessions.js'
 
 const users = authSchema.table(
   'users',
-  {
-    id: uuid('id').primaryKey().defaultRandom(),
-    hashedPassword: text('hashed_password').notNull(),
-    username: citext('username').notNull(),
-  },
-  (table) => ({
-    uk1: namedUnique(table.username),
+  (t) => ({
+    id: t.uuid().primaryKey().defaultRandom(),
+    hashedPassword: t.text().notNull(),
+    username: citext().notNull(),
+  }),
+  (t) => ({
+    uk1: namedUnique(t.username),
   }),
 )
 


### PR DESCRIPTION
Drizzle added an option to not have to
specify column name in just use the key
name. In addition, specify the default casing 
to be 'snake_case'.