### PR TITLE
refactor(packages/db-drizzlepg): use table suffix for all table variable names

### DIFF
--- a/packages/db-drizzlepg/src/schema/auth/index.ts
+++ b/packages/db-drizzlepg/src/schema/auth/index.ts
@@ -1,5 +1,5 @@
 export { authSchema } from './schema.js'
 
-export { type Session, sessionRelations, default as sessionsTable } from './sessions.js'
+export { type Session, sessionRelations, sessionsTable } from './sessions.js'
 
-export { type User, userRelations, default as usersTable } from './users.js'
+export { type User, userRelations, usersTable } from './users.js'

--- a/packages/db-drizzlepg/src/schema/auth/sessions.ts
+++ b/packages/db-drizzlepg/src/schema/auth/sessions.ts
@@ -4,25 +4,23 @@ import { text, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { namedForeignKey } from '../utils.js'
 
 import { authSchema } from './schema.js'
-import users from './users.js'
+import { usersTable } from './users.js'
 
-export const sessions = authSchema.table(
+export const sessionsTable = authSchema.table(
   'sessions',
   {
     id: text().primaryKey(),
     expiresAt: timestamp({ mode: 'date', withTimezone: true }).notNull(),
     userId: uuid().notNull(),
   },
-  (t) => [namedForeignKey(t.userId, users.id)],
+  (t) => [namedForeignKey(t.userId, usersTable.id)],
 )
 
-export default sessions
-
-export const sessionRelations = relations(sessions, ({ one }) => ({
-  user: one(users, {
-    fields: [sessions.userId],
-    references: [users.id],
+export const sessionRelations = relations(sessionsTable, ({ one }) => ({
+  user: one(usersTable, {
+    fields: [sessionsTable.userId],
+    references: [usersTable.id],
   }),
 }))
 
-export type Session = typeof sessions.$inferSelect
+export type Session = typeof sessionsTable.$inferSelect

--- a/packages/db-drizzlepg/src/schema/auth/users.ts
+++ b/packages/db-drizzlepg/src/schema/auth/users.ts
@@ -4,9 +4,9 @@ import { citext } from '../custom-types.js'
 import { namedUnique } from '../utils.js'
 
 import { authSchema } from './schema.js'
-import sessions from './sessions.js'
+import { sessionsTable } from './sessions.js'
 
-const users = authSchema.table(
+export const usersTable = authSchema.table(
   'users',
   (t) => ({
     id: t.uuid().primaryKey().defaultRandom(),
@@ -16,10 +16,8 @@ const users = authSchema.table(
   (t) => [namedUnique(t.username)],
 )
 
-export default users
-
-export const userRelations = relations(users, ({ many }) => ({
-  sessions: many(sessions),
+export const userRelations = relations(usersTable, ({ many }) => ({
+  sessions: many(sessionsTable),
 }))
 
-export type User = typeof users.$inferSelect
+export type User = typeof usersTable.$inferSelect


### PR DESCRIPTION
Changing the naming convention to improve
consistency around table name variables.
Previously was using table suffix only when
exporting. Also stopped using default export
as the names are no consistent.