### PR TITLE
refactor(@apps/sveltekit-example-app): svelte5 upgrade cleanup

### DIFF
--- a/.github/workflows/monorepo-health.yml
+++ b/.github/workflows/monorepo-health.yml
@@ -16,6 +16,3 @@ jobs:
 
       - name: Run One Version check
         run: pnpm run one-version:check
-
-      - name: Test dedupe
-        run: pnpm dedupe --check

--- a/.github/workflows/monorepo-health.yml
+++ b/.github/workflows/monorepo-health.yml
@@ -16,3 +16,6 @@ jobs:
 
       - name: Run One Version check
         run: pnpm run one-version:check
+
+      - name: Test dedupe
+        run: pnpm dedupe --check

--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -33,7 +33,6 @@
     "svelte-check": "4.1.1",
     "sveltekit-superforms": "2.21.1",
     "tailwindcss": "4.0.0-beta.7",
-    "tslib": "2.8.1",
     "vite": "6.0.3",
     "zod": "3.24.1"
   }

--- a/packages/ui-lib-svelte/package.json
+++ b/packages/ui-lib-svelte/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@packages/ui-lib-svelte",
   "version": "0.0.0",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "type": "module",
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "svelte": "./src/index.ts",
-      "default": "./src/index.ts"
+      "svelte": "./src/index.ts"
     }
   },
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "svelte-kit sync",
     "clean": "del .turbo coverage .svelte-kit",
@@ -28,7 +28,6 @@
     "@toolchain/vitest-config": "workspace:*",
     "svelte": "5.12.0",
     "svelte-check": "4.1.1",
-    "tslib": "2.8.1",
     "vite": "6.0.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       tailwindcss:
         specifier: 4.0.0-beta.7
         version: 4.0.0-beta.7
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       vite:
         specifier: 6.0.3
         version: 6.0.3(@types/node@22.9.1)(jiti@2.4.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       svelte-check:
         specifier: 4.1.1
         version: 4.1.1(picomatch@4.0.2)(svelte@5.12.0)(typescript@5.7.2)
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       vite:
         specifier: 6.0.3
         version: 6.0.3(@types/node@22.9.1)(jiti@2.4.1)(lightningcss@1.28.2)(tsx@4.19.2)(yaml@2.6.1)


### PR DESCRIPTION
* remove tslib dependency as not being used in new `sv create` apps.
* add sideEffect key in package.json. This is supposed to help with 
  tree-shaking issues with css files in the ui-lib-svelte package.