### PR TITLE
feat(@packages/db-drizzlepg): add ability to start drizzle studio in package.json script

### DIFF
--- a/packages/db-drizzlepg/package.json
+++ b/packages/db-drizzlepg/package.json
@@ -14,6 +14,7 @@
     "db:generate": "node --import=tsx ./node_modules/drizzle-kit/bin.cjs generate",
     "db:migrate": "node --import=tsx ./src/migrate.ts",
     "db:push": "node --import=tsx ./node_modules/drizzle-kit/bin.cjs push",
+    "db:studio": "node --import=tsx ./node_modules/drizzle-kit/bin.cjs studio",
     "lint": "eslint .",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Drizzle Studio use to have issues with custom datatype like `citext` but this looks to be resolved now.