### PR TITLE
feat(monorepo): ensure that only a single workflow will run at a time

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: ESLint

--- a/.github/workflows/monorepo-health.yml
+++ b/.github/workflows/monorepo-health.yml
@@ -1,6 +1,12 @@
 name: monorepo-health
 on:
   pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   one-version-check:


### PR DESCRIPTION
The key is:
* The name of the workflow.
* The fully-formed ref of the branch or tag that triggered the workflow run.