### PR TITLE
refactor(packages/db-drizzlepg): update drizzle connection approach

### DIFF
--- a/packages/db-drizzlepg/src/client/pg-client.ts
+++ b/packages/db-drizzlepg/src/client/pg-client.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/node-postgres'
-import { Pool } from 'pg'
+import pg from 'pg'
 
 import * as schema from '../schema/index.js'
 
@@ -14,7 +14,7 @@ const {
   DB_MAX_CONNECTIONS,
 } = env
 
-export const connection = new Pool({
+const connection = new pg.Pool({
   connectionString: DB_CONNECTION_STRING,
 
   application_name: DB_APPLICATION_NAME,
@@ -40,8 +40,9 @@ if (DB_LOGGING_ENABLED) {
   connection.on('remove', () => console.debug('Removed the connection from the pool'))
 }
 
-export const db = drizzle(connection, {
+export const db = drizzle({
   casing: 'snake_case',
+  client: connection,
   logger: DB_LOGGING_ENABLED ? new QueryLogger() : false,
   schema,
 })

--- a/packages/db-drizzlepg/src/migrate.ts
+++ b/packages/db-drizzlepg/src/migrate.ts
@@ -1,17 +1,17 @@
 import { migrate } from 'drizzle-orm/postgres-js/migrator'
 
-import { connection, db } from './client/pg-client.js'
+import { db } from './client/index.js'
 
 try {
   console.log('Drizzle database migration starting...')
 
   await migrate(db, {
-    migrationsFolder: './drizzle',
+    migrationsFolder: './src/migrations',
   })
 
   console.log('Drizzle database migration completed successfully!')
 } catch (error) {
   console.log('Drizzle database migrations failed!', error)
 } finally {
-  await connection.end()
+  await db.$client.end()
 }


### PR DESCRIPTION
Drizzle since 0.34.0 has changed how to
create a database connection. The old way
won't be deprecated until 1.0, but wanted
to get ahead of this change now rather
than later.

see https://github.com/drizzle-team/drizzle-orm/discussions/3097