### PR TITLE
refactor(apps/sveltekit-examplea-app): add full type safety for $props

### DIFF
--- a/apps/sveltekit-example-app/src/routes/+layout.svelte
+++ b/apps/sveltekit-example-app/src/routes/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import '../app.css'
+  import type { LayoutProps } from './$types.js'
 
-  const { children } = $props()
+  const { children }: LayoutProps = $props()
 </script>
 
 {@render children()}

--- a/apps/sveltekit-example-app/src/routes/+page.svelte
+++ b/apps/sveltekit-example-app/src/routes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  const { data } = $props()
+  import type { PageProps } from './$types.js'
+
+  const { data }: PageProps = $props()
 </script>
 
 <div class="space-y-1">

--- a/apps/sveltekit-example-app/src/routes/account/sign-up/+page.svelte
+++ b/apps/sveltekit-example-app/src/routes/account/sign-up/+page.svelte
@@ -4,7 +4,9 @@
 
   import { signupSchema } from '$lib/schemas/index.js'
 
-  const { data } = $props()
+  import type { PageProps } from './$types.js'
+
+  const { data }: PageProps = $props()
 
   const form = superForm(data.form, {
     validationMethod: 'auto',


### PR DESCRIPTION
With the release of SvelteKit 2.16.0,
new types PageProps and LayoutProps are
introduced to simplify the type
annotation for props in +page.svelte and
+layout.svelte respectively.