### PR TITLE
feat(toolchain/typescript-config): add new interop constraint compiler option

### DIFF
--- a/toolchain/typescript-config/base/tsconfig-base.json
+++ b/toolchain/typescript-config/base/tsconfig-base.json
@@ -27,8 +27,8 @@
     "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
 
     /* Interop Constraints */
-    "isolatedModules": false,                         /* Ensure that each file can be safely transpiled without relying on other imports. */
     "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript */
     "esModuleInterop": true,                          /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
 


### PR DESCRIPTION
Typescript 5.8 added new option called erasableSyntaxOnly. erasableSyntaxOnly marks enums, namespaces and class parameter properties as errors. These pieces of syntax are not considered erasable.
Basically it disables a bunch of features that should ever have been part of TypeScript