### PR TITLE
feat(toolchain/eslint-config): revamp modular configuration approach for svelte profile

### DIFF
--- a/apps/hono-node-app/eslint.config.js
+++ b/apps/hono-node-app/eslint.config.js
@@ -1,1 +1,12 @@
-export { default } from '@toolchain/eslint-config/profile/node'
+import config from '@toolchain/eslint-config-new/profile/node'
+
+export default [
+  ...config,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/apps/hono-node-app/package.json
+++ b/apps/hono-node-app/package.json
@@ -19,7 +19,7 @@
     "zod": "3.24.2"
   },
   "devDependencies": {
-    "@toolchain/eslint-config": "workspace:*",
+    "@toolchain/eslint-config-new": "workspace:*",
     "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
     "tsx": "4.19.3"

--- a/apps/sveltekit-example-app/eslint.config.js
+++ b/apps/sveltekit-example-app/eslint.config.js
@@ -1,17 +1,27 @@
-import config from '@toolchain/eslint-config/profile/svelte'
+import config from '@toolchain/eslint-config-new/profile/svelte'
+
+import svelteConfig from './svelte.config.js'
+
+delete svelteConfig.kit.typescript.config
 
 export default [
   ...config,
   {
-    // TODO: Once settled this config must be moved to @toolchain/eslint-config
     files: ['**/*.svelte', '**/*.svelte.ts'],
+    languageOptions: {
+      parserOptions: {
+        svelteConfig,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
+      // TODO: Once settled this config must be moved to @toolchain/eslint-config
       // Turning these off as they currently interfere with SvelteKit 5
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
+      // '@typescript-eslint/explicit-module-boundary-types': 'off',
+      // '@typescript-eslint/no-unsafe-argument': 'off',
+      // '@typescript-eslint/no-unsafe-assignment': 'off',
+      // '@typescript-eslint/no-unsafe-call': 'off',
+      // '@typescript-eslint/no-unsafe-member-access': 'off',
     },
   },
 ]

--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -25,7 +25,7 @@
     "@sveltejs/kit": "2.19.0",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@tailwindcss/vite": "4.0.12",
-    "@toolchain/eslint-config": "workspace:*",
+    "@toolchain/eslint-config-new": "workspace:*",
     "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
     "http-status-codes": "2.3.0",

--- a/packages/ui-lib-svelte/eslint.config.js
+++ b/packages/ui-lib-svelte/eslint.config.js
@@ -1,1 +1,18 @@
-export { default } from '@toolchain/eslint-config/profile/svelte'
+import config from '@toolchain/eslint-config-new/profile/svelte'
+
+import svelteConfig from './svelte.config.js'
+
+delete svelteConfig.kit.typescript.config
+
+export default [
+  ...config,
+  {
+    files: ['**/*.svelte', '**/*.svelte.ts'],
+    languageOptions: {
+      parserOptions: {
+        svelteConfig,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/ui-lib-svelte/package.json
+++ b/packages/ui-lib-svelte/package.json
@@ -24,7 +24,7 @@
     "@sveltejs/kit": "2.19.0",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@tailwindcss/vite": "4.0.12",
-    "@toolchain/eslint-config": "workspace:*",
+    "@toolchain/eslint-config-new": "workspace:*",
     "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
     "bits-ui": "1.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,9 @@ importers:
         specifier: 3.24.2
         version: 3.24.2
     devDependencies:
-      '@toolchain/eslint-config':
+      '@toolchain/eslint-config-new':
         specifier: workspace:*
-        version: link:../../toolchain/eslint-config
+        version: link:../../toolchain/eslint-config-new
       '@toolchain/typescript-config':
         specifier: workspace:*
         version: link:../../toolchain/typescript-config
@@ -97,9 +97,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.0.12
         version: 4.0.12(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
-      '@toolchain/eslint-config':
+      '@toolchain/eslint-config-new':
         specifier: workspace:*
-        version: link:../../toolchain/eslint-config
+        version: link:../../toolchain/eslint-config-new
       '@toolchain/typescript-config':
         specifier: workspace:*
         version: link:../../toolchain/typescript-config
@@ -299,9 +299,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 4.0.12
         version: 4.0.12(vite@6.2.1(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.0))
-      '@toolchain/eslint-config':
+      '@toolchain/eslint-config-new':
         specifier: workspace:*
-        version: link:../../toolchain/eslint-config
+        version: link:../../toolchain/eslint-config-new
       '@toolchain/typescript-config':
         specifier: workspace:*
         version: link:../../toolchain/typescript-config
@@ -423,6 +423,9 @@ importers:
       eslint-plugin-promise:
         specifier: 7.2.1
         version: 7.2.1(eslint@9.22.0(jiti@2.4.2))
+      eslint-plugin-svelte:
+        specifier: 3.1.0
+        version: 3.1.0(eslint@9.22.0(jiti@2.4.2))(svelte@5.22.6)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
       eslint-plugin-unicorn:
         specifier: 57.0.0
         version: 57.0.0(eslint@9.22.0(jiti@2.4.2))
@@ -2557,6 +2560,12 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  eslint-compat-utils@0.6.4:
+    resolution: {integrity: sha512-/u+GQt8NMfXO8w17QendT4gvO5acfxQsAKirAt0LVxDnr2N8YLCVbregaNc/Yhp7NM128DwCaRvr8PLDfeNkQw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   eslint-config-prettier@10.1.1:
     resolution: {integrity: sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==}
     hasBin: true
@@ -2643,6 +2652,16 @@ packages:
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0-0 || ^9.0.0-0
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  eslint-plugin-svelte@3.1.0:
+    resolution: {integrity: sha512-hSQyLDkuuHPJby1ixZfUVrfLON42mT0Odf18MbwAgFUPuyIwJlhy3acUY1/bxt+Njucq/dQxR543zYDqkBNLmw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.1 || ^9.0.0
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
@@ -3937,6 +3956,12 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
@@ -4477,6 +4502,15 @@ packages:
   svelte-eslint-parser@1.0.0:
     resolution: {integrity: sha512-diZzpeeFhAxormeIhmRS4vXx98GG6T7Dq5y1a6qffqs/5MBrBqqDg8bj88iEohp6bvhU4MIABJmOTa0gXWcbSQ==}
     engines: {node: ^18.20.4 || ^20.18.0 || >=22.10.0}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  svelte-eslint-parser@1.0.1:
+    resolution: {integrity: sha512-JjdEMXOJqy+dxeaElxbN+meTOtVpHfLnq9VGpiTAOLgM0uHO+ogmUsA3IFgx0x3Wl15pqTZWycCikcD7cAQN/g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
@@ -7043,6 +7077,11 @@ snapshots:
       eslint: 9.22.0(jiti@2.4.2)
       semver: 7.7.1
 
+  eslint-compat-utils@0.6.4(eslint@9.22.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.22.0(jiti@2.4.2)
+      semver: 7.7.1
+
   eslint-config-prettier@10.1.1(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.22.0(jiti@2.4.2)
@@ -7151,6 +7190,24 @@ snapshots:
       postcss-selector-parser: 6.1.2
       semver: 7.7.1
       svelte-eslint-parser: 0.43.0(svelte@5.22.6)
+    optionalDependencies:
+      svelte: 5.22.6
+    transitivePeerDependencies:
+      - ts-node
+
+  eslint-plugin-svelte@3.1.0(eslint@9.22.0(jiti@2.4.2))(svelte@5.22.6)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.22.0(jiti@2.4.2))
+      '@jridgewell/sourcemap-codec': 1.5.0
+      eslint: 9.22.0(jiti@2.4.2)
+      eslint-compat-utils: 0.6.4(eslint@9.22.0(jiti@2.4.2))
+      esutils: 2.0.3
+      known-css-properties: 0.35.0
+      postcss: 8.5.3
+      postcss-load-config: 3.1.4(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      postcss-safe-parser: 7.0.1(postcss@8.5.3)
+      semver: 7.7.1
+      svelte-eslint-parser: 1.0.1(svelte@5.22.6)
     optionalDependencies:
       svelte: 5.22.6
     transitivePeerDependencies:
@@ -8509,6 +8566,10 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  postcss-safe-parser@7.0.1(postcss@8.5.3):
+    dependencies:
+      postcss: 8.5.3
+
   postcss-scss@4.0.9(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -9016,6 +9077,17 @@ snapshots:
       svelte: 5.22.6
 
   svelte-eslint-parser@1.0.0(svelte@5.22.6):
+    dependencies:
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      postcss: 8.5.3
+      postcss-scss: 4.0.9(postcss@8.5.3)
+      postcss-selector-parser: 7.1.0
+    optionalDependencies:
+      svelte: 5.22.6
+
+  svelte-eslint-parser@1.0.1(svelte@5.22.6):
     dependencies:
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0

--- a/toolchain/eslint-config-new/configs/global-ignores.js
+++ b/toolchain/eslint-config-new/configs/global-ignores.js
@@ -4,6 +4,6 @@ export default config([
   {
     name: 'eslint-config:config:global-ignores',
 
-    ignores: ['coverage'],
+    ignores: ['coverage', '.svelte-kit', 'build'],
   },
 ])

--- a/toolchain/eslint-config-new/configs/prettier.js
+++ b/toolchain/eslint-config-new/configs/prettier.js
@@ -1,4 +1,5 @@
 import prettierPlugin from 'eslint-config-prettier'
+import sveltePlugin from 'eslint-plugin-svelte'
 import { config } from 'typescript-eslint'
 
 /**
@@ -9,4 +10,4 @@ import { config } from 'typescript-eslint'
  *
  * !IMPORTANT!: This configuration MUST always appear last in any ESLint profile definition.
  */
-export default config(prettierPlugin)
+export default config(prettierPlugin, ...sveltePlugin.configs.prettier)

--- a/toolchain/eslint-config-new/configs/svelte.js
+++ b/toolchain/eslint-config-new/configs/svelte.js
@@ -1,0 +1,27 @@
+import plugin from 'eslint-plugin-svelte'
+import { config, parser } from 'typescript-eslint'
+
+import typescriptConfig from './typescript.js'
+
+export default config(
+  {
+    extends: [typescriptConfig],
+    files: ['**/*.svelte'],
+    rules: {
+      'svelte/block-lang': ['error', { script: 'ts', style: ['postcss', 'css'] }],
+      'svelte/max-attributes-per-line': 'error',
+      'svelte/sort-attributes': 'error',
+    },
+  },
+  {
+    files: ['**/*.svelte', '**/*.svelte.ts'],
+    languageOptions: {
+      parserOptions: {
+        extraFileExtensions: ['.svelte'], // Add support for additional file extensions, such as .svelte
+        parser: parser,
+        projectService: true,
+      },
+    },
+  },
+  ...plugin.configs.recommended,
+)

--- a/toolchain/eslint-config-new/package.json
+++ b/toolchain/eslint-config-new/package.json
@@ -5,7 +5,8 @@
   "license": "UNLICENSED",
   "type": "module",
   "exports": {
-    "./profile/node": "./profile/node.js"
+    "./profile/node": "./profile/node.js",
+    "./profile/svelte": "./profile/svelte-profile.js"
   },
   "scripts": {
     "clean": "del .turbo",
@@ -22,6 +23,7 @@
     "eslint-plugin-perfectionist": "4.10.1",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-promise": "7.2.1",
+    "eslint-plugin-svelte": "3.1.0",
     "eslint-plugin-unicorn": "57.0.0",
     "typescript-eslint": "8.26.0"
   },

--- a/toolchain/eslint-config-new/profile/svelte-profile.js
+++ b/toolchain/eslint-config-new/profile/svelte-profile.js
@@ -1,0 +1,32 @@
+import globals from 'globals'
+import { config } from 'typescript-eslint'
+
+import baseConfig from '../configs/base.js'
+import globalIgnoresConfig from '../configs/global-ignores.js'
+import javascriptConfig from '../configs/javascript.js'
+import prettierConfig from '../configs/prettier.js'
+import svelteConfig from '../configs/svelte.js'
+import typescriptConfig from '../configs/typescript.js'
+import vitestConfig from '../configs/vitest.js'
+
+const { browser, nodeBuiltin } = globals
+
+export default config(
+  javascriptConfig,
+  typescriptConfig,
+  svelteConfig,
+  vitestConfig,
+  baseConfig,
+  prettierConfig,
+  globalIgnoresConfig,
+  {
+    name: 'eslint-config:profile:svelte',
+
+    languageOptions: {
+      globals: {
+        ...browser,
+        ...nodeBuiltin,
+      },
+    },
+  },
+)


### PR DESCRIPTION
Original configuration was created at a time when
most of the eslint plugins were not supporting flat config. As a result, there was some clever ways to get around mixing legacy config with flat config. This new approach utilized the newer flat configs provided by the plugins themselves while still keeping with the modularity of the configs, housing the specific plugin config to individual files.