### PR TITLE
fix(packages/db-drizzlepg): fix import/no-cycle issues

### DIFF
--- a/packages/db-drizzlepg/src/schema/auth/index.ts
+++ b/packages/db-drizzlepg/src/schema/auth/index.ts
@@ -1,10 +1,7 @@
+export { sessionRelations, userRelations } from './relations.js'
+
 export { authSchema } from './schema.js'
 
-export {
-  type SessionEntity,
-  type SessionEntityInsert,
-  sessionRelations,
-  sessionsTable,
-} from './sessions.js'
+export { type SessionEntity, type SessionEntityInsert, sessionsTable } from './sessions.js'
 
-export { type UserEntity, type UserEntityInsert, userRelations, usersTable } from './users.js'
+export { type UserEntity, type UserEntityInsert, usersTable } from './users.js'

--- a/packages/db-drizzlepg/src/schema/auth/relations.ts
+++ b/packages/db-drizzlepg/src/schema/auth/relations.ts
@@ -1,0 +1,15 @@
+import { relations } from 'drizzle-orm'
+
+import { sessionsTable } from './sessions.js'
+import { usersTable } from './users.js'
+
+export const userRelations = relations(usersTable, ({ many }) => ({
+  sessions: many(sessionsTable),
+}))
+
+export const sessionRelations = relations(sessionsTable, ({ one }) => ({
+  user: one(usersTable, {
+    fields: [sessionsTable.userId],
+    references: [usersTable.id],
+  }),
+}))

--- a/packages/db-drizzlepg/src/schema/auth/sessions.ts
+++ b/packages/db-drizzlepg/src/schema/auth/sessions.ts
@@ -1,4 +1,3 @@
-import { relations } from 'drizzle-orm'
 import { text, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 import { namedForeignKey } from '../helpers.js'
@@ -16,12 +15,5 @@ export const sessionsTable = authSchema.table(
   (t) => [namedForeignKey(t.userId, usersTable.id)],
 )
 
-export const sessionRelations = relations(sessionsTable, ({ one }) => ({
-  user: one(usersTable, {
-    fields: [sessionsTable.userId],
-    references: [usersTable.id],
-  }),
-}))
-
 export type SessionEntity = typeof sessionsTable.$inferSelect
-export type SessionEntityInsert = typeof sessionsTable.$inferSelect
+export type SessionEntityInsert = typeof sessionsTable.$inferInsert

--- a/packages/db-drizzlepg/src/schema/auth/users.ts
+++ b/packages/db-drizzlepg/src/schema/auth/users.ts
@@ -1,11 +1,9 @@
-import { relations } from 'drizzle-orm'
 import { text } from 'drizzle-orm/pg-core'
 
 import { citext } from '../custom-types.js'
 import { namedUnique, withSurrogateId } from '../helpers.js'
 
 import { authSchema } from './schema.js'
-import { sessionsTable } from './sessions.js'
 
 export const usersTable = authSchema.table(
   'users',
@@ -16,10 +14,6 @@ export const usersTable = authSchema.table(
   },
   (t) => [namedUnique(t.username)],
 )
-
-export const userRelations = relations(usersTable, ({ many }) => ({
-  sessions: many(sessionsTable),
-}))
 
 export type UserEntity = Omit<typeof usersTable.$inferSelect, 'hashedPassword'>
 export type UserEntityInsert = typeof usersTable.$inferInsert


### PR DESCRIPTION
Defining relations in respective table
definitions file is problematic in that it you
will end up with an import cycle issue where
table_a will import table_b and table_b will
import table_a when there is a relationship
between the two tables.