### PR TITLE
feat(packages/db-drizzlepg): add status and name fields, remove user schema

### DIFF
--- a/packages/api/src/controllers/accounts.controller.ts
+++ b/packages/api/src/controllers/accounts.controller.ts
@@ -24,7 +24,13 @@ const app = new Hono<CustomEnv>()
   .post('/signup', zValidator('json', signupSchema), async (c) => {
     const { password, username } = c.req.valid('json')
     try {
-      const userId = await createUser({ password, username })
+      const userId = await createUser({
+        id: '',
+        firstName: null,
+        lastName: null,
+        password,
+        username,
+      })
       if (userId) {
         return c.json({
           accessToken: 'session-12345',

--- a/packages/api/src/services/account.services.ts
+++ b/packages/api/src/services/account.services.ts
@@ -2,22 +2,25 @@ import { hash } from '@node-rs/argon2'
 
 import { db } from '@packages/db-drizzlepg/client'
 import {
-  type UserEntity,
-  type UserEntityInsert,
+  type NewUserAccountEntity,
+  type UserAccountEntity,
   userAccountsTable,
 } from '@packages/db-drizzlepg/schema'
 
-export type NewUser = Omit<UserEntityInsert, 'hashedPassword'> & {
-  password: string
-}
-
-export const findByUsername = async (username: string): Promise<UserEntity | undefined> =>
+export const findByUsername = async (username: string): Promise<UserAccountEntity | undefined> =>
   db.query.userAccountsTable.findFirst({
-    columns: { id: true, hashedPassword: true, username: true },
+    columns: {
+      id: true,
+      firstName: true,
+      hashedPassword: true,
+      lastName: true,
+      status: true,
+      username: true,
+    },
     where: { username },
   })
 
-export const createUser = async (user: NewUser): Promise<string | undefined> => {
+export const createUser = async (user: NewUserAccountEntity): Promise<string | undefined> => {
   const hashedPassword = await hash(user.password)
 
   return db

--- a/packages/db-drizzlepg/src/schema/user/accounts.ts
+++ b/packages/db-drizzlepg/src/schema/user/accounts.ts
@@ -1,19 +1,35 @@
-import { text } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import { check, pgTable, text } from 'drizzle-orm/pg-core'
 
 import { citext } from '../custom-types.js'
 import { namedUnique, withSurrogateId } from '../helpers.js'
 
-import { userSchema } from './schema.js'
+const accountStatus = ['active', 'inactive', 'dormant', 'closed', 'suspended'] as const
+type AccountStatus = (typeof accountStatus)[number]
 
-export const userAccountsTable = userSchema.table(
-  'users',
+export const userAccountsTable = pgTable(
+  'user_accounts',
   {
     ...withSurrogateId,
+    firstName: text(),
     hashedPassword: text().notNull(),
+    lastName: text(),
+    status: text().$type<AccountStatus>().notNull().default('inactive'),
     username: citext().notNull(),
   },
-  (t) => [namedUnique(t.username)],
+  (t) => [
+    namedUnique(t.username),
+    check(
+      'user_accounts_chk_status',
+      sql`${t.status} in ${sql.raw(`'${accountStatus.join("','")}'`)}`,
+    ),
+  ],
 )
 
-export type UserEntity = Omit<typeof userAccountsTable.$inferSelect, 'hashedPassword'>
-export type UserEntityInsert = typeof userAccountsTable.$inferInsert
+export type UserAccountEntity = Omit<typeof userAccountsTable.$inferSelect, 'hashedPassword'>
+export type NewUserAccountEntity = Omit<
+  typeof userAccountsTable.$inferSelect,
+  'hashedPassword' | 'status'
+> & {
+  password: string
+}

--- a/packages/db-drizzlepg/src/schema/user/index.ts
+++ b/packages/db-drizzlepg/src/schema/user/index.ts
@@ -1,5 +1,2 @@
-export { userAccountsTable, type UserEntity, type UserEntityInsert } from './accounts.js'
-
-export { userSchema } from './schema.js'
-
-export { type SessionEntity, type SessionEntityInsert, userSessionsTable } from './sessions.js'
+export * from './accounts.js'
+export * from './sessions.js'

--- a/packages/db-drizzlepg/src/schema/user/schema.ts
+++ b/packages/db-drizzlepg/src/schema/user/schema.ts
@@ -1,3 +1,0 @@
-import { pgSchema } from 'drizzle-orm/pg-core'
-
-export const userSchema = pgSchema('user')

--- a/packages/db-drizzlepg/src/schema/user/sessions.ts
+++ b/packages/db-drizzlepg/src/schema/user/sessions.ts
@@ -1,12 +1,11 @@
-import { timestamp, uuid } from 'drizzle-orm/pg-core'
+import { pgTable, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 import { namedForeignKey, withSurrogateId } from '../helpers.js'
 
 import { userAccountsTable } from './accounts.js'
-import { userSchema } from './schema.js'
 
-export const userSessionsTable = userSchema.table(
-  'sessions',
+export const userSessionsTable = pgTable(
+  'user_sessions',
   {
     ...withSurrogateId,
     expiresAt: timestamp({ mode: 'date', withTimezone: true }).notNull(),
@@ -15,5 +14,5 @@ export const userSessionsTable = userSchema.table(
   (t) => [namedForeignKey(t.userId, userAccountsTable.id).onDelete('cascade')],
 )
 
-export type SessionEntity = typeof userSessionsTable.$inferSelect
-export type SessionEntityInsert = typeof userSessionsTable.$inferInsert
+export type UserSessionEntity = typeof userSessionsTable.$inferSelect
+export type NewUserSessionEntity = typeof userSessionsTable.$inferInsert


### PR DESCRIPTION
The changes add status and name fields to user accounts, and reorganize the database schema structure by removing the user schema namespace.