### PR TITLE
refactor(packages/api-hono): move middleware out of create-app.ts

### DIFF
--- a/packages/api-hono/src/client/index.ts
+++ b/packages/api-hono/src/client/index.ts
@@ -1,6 +1,8 @@
 import { type ClientRequestOptions, hc } from 'hono/client'
 
-import type { AppType } from '../index.js'
+import type app from '../index.js'
+
+type AppType = typeof app
 
 export type ApiClient = ReturnType<typeof hc<AppType>>
 

--- a/packages/api-hono/src/index.ts
+++ b/packages/api-hono/src/index.ts
@@ -1,12 +1,19 @@
+import { logger } from 'hono/logger'
+
 import { configureOpenAPI } from './lib/configure-openapi.js'
 import { createApp } from './lib/create-app.js'
 import taskRoutes from './routes/tasks/tasks.index.js'
 
-const app = createApp('/api') //
+const rootApp = createApp()
+
+rootApp.use('*', logger())
+
+const app = rootApp //
+  .basePath('/api')
   .route('/', taskRoutes)
 
 configureOpenAPI(app)
 
-export type AppType = typeof app
-
 export default app
+
+console.log(app.routes)

--- a/packages/api-hono/src/lib/create-app.ts
+++ b/packages/api-hono/src/lib/create-app.ts
@@ -1,5 +1,4 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
-import { logger } from 'hono/logger'
 
 import type { AppOpenApi, CustomEnv } from './types.js'
 
@@ -7,15 +6,16 @@ import { defaultHook } from '../middlewares/default-hook.js'
 import { notFound, onError } from '../middlewares/index.js'
 
 export const createRouter = (): AppOpenApi =>
-  new OpenAPIHono<CustomEnv>({ defaultHook, strict: true })
+  new OpenAPIHono<CustomEnv>({
+    defaultHook,
+    strict: true,
+  })
 
-export const createApp = (basePath = '/'): AppOpenApi => {
-  const app = createRouter().basePath(basePath)
+export const createApp = (): AppOpenApi => {
+  const app = createRouter()
 
   app.notFound(notFound)
   app.onError(onError)
-
-  app.use('*', logger())
 
   return app
 }


### PR DESCRIPTION
Moving setting middleware out of create-app
so that this function can be made as a
reusable utility function.