### PR TITLE
fix(packages/api-hono): rework basepath setup plus code cleanup

### DIFF
--- a/packages/api-hono/package.json
+++ b/packages/api-hono/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "0.19.2",
-    "@hono/zod-validator": "0.4.3",
     "@scalar/hono-api-reference": "0.8.0",
     "hono": "4.7.5",
     "http-status-codes": "2.3.0",

--- a/packages/api-hono/src/index.ts
+++ b/packages/api-hono/src/index.ts
@@ -1,19 +1,23 @@
+import { showRoutes } from 'hono/dev'
 import { logger } from 'hono/logger'
 
 import { configureOpenAPI } from './lib/configure-openapi.js'
 import { createApp } from './lib/create-app.js'
 import taskRoutes from './routes/tasks/tasks.index.js'
 
-const rootApp = createApp()
+const app = createApp('/api')
 
-rootApp.use('*', logger())
+app.use('*', logger())
 
-const app = rootApp //
-  .basePath('/api')
+const routes = app //
   .route('/', taskRoutes)
 
-configureOpenAPI(app)
+configureOpenAPI(routes)
 
 export default app
 
-console.log(app.routes)
+if (process.env['NODE_ENV'] !== 'production') {
+  console.log('*** Available routes')
+  showRoutes(app, { colorize: true, verbose: true })
+  console.log('***')
+}

--- a/packages/api-hono/src/lib/create-app.ts
+++ b/packages/api-hono/src/lib/create-app.ts
@@ -2,17 +2,16 @@ import { OpenAPIHono } from '@hono/zod-openapi'
 
 import type { AppOpenApi, CustomEnv } from './types.js'
 
-import { defaultHook } from '../middlewares/default-hook.js'
-import { notFound, onError } from '../middlewares/index.js'
+import { defaultHook, notFound, onError } from '../middlewares/index.js'
 
-export const createRouter = (): AppOpenApi =>
+export const createRouter = (basePath = '/'): AppOpenApi =>
   new OpenAPIHono<CustomEnv>({
     defaultHook,
     strict: true,
-  })
+  }).basePath(basePath)
 
-export const createApp = (): AppOpenApi => {
-  const app = createRouter()
+export const createApp = (basePath = '/'): AppOpenApi => {
+  const app = createRouter(basePath)
 
   app.notFound(notFound)
   app.onError(onError)

--- a/packages/api-hono/src/middlewares/default-hook.ts
+++ b/packages/api-hono/src/middlewares/default-hook.ts
@@ -6,14 +6,12 @@ import { StatusCodes } from 'http-status-codes'
 import type { CustomEnv } from '../lib/types.js'
 
 export const defaultHook: Hook<unknown, CustomEnv, never, unknown> = (result, _ctx) => {
-  console.error('Global HonoZodOpenApiHook', JSON.stringify(result, null, 2))
+  if (!result.success) {
+    console.error('Global HonoZodOpenApiHook', JSON.stringify(result, null, 2))
 
-  if (result.success) {
-    return
+    throw new HTTPException(StatusCodes.BAD_REQUEST, {
+      cause: result.error.errors,
+      message: 'Validation failed',
+    })
   }
-
-  throw new HTTPException(StatusCodes.BAD_REQUEST, {
-    cause: result.error.errors,
-    message: 'Validation failed',
-  })
 }

--- a/packages/api-hono/src/middlewares/index.ts
+++ b/packages/api-hono/src/middlewares/index.ts
@@ -1,2 +1,3 @@
+export { defaultHook } from './default-hook.js'
 export { notFound } from './not-found.js'
 export { onError } from './on-error.js'

--- a/packages/api-hono/src/routes/tasks/tasks.index.ts
+++ b/packages/api-hono/src/routes/tasks/tasks.index.ts
@@ -3,8 +3,7 @@ import { createRouter } from '../../lib/create-app.js'
 import * as handlers from './tasks.handlers.js'
 import * as routes from './tasks.routes.js'
 
-const router = createRouter() //
-  .basePath('/tasks')
+const router = createRouter('/tasks') //
   .openapi(routes.findOne, handlers.findOne)
 
 export default router

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       '@hono/zod-openapi':
         specifier: 0.19.2
         version: 0.19.2(hono@4.7.5)(zod@3.24.2)
-      '@hono/zod-validator':
-        specifier: 0.4.3
-        version: 0.4.3(hono@4.7.5)(zod@3.24.2)
       '@scalar/hono-api-reference':
         specifier: 0.8.0
         version: 0.8.0(hono@4.7.5)


### PR DESCRIPTION
Placement of where to put basePath and
impact on middleware behavior is still
a bit of a mystery. But this is a current
working version of a valid approach.