### PR TITLE
feat(toolchain/eslint-config): remove @typescript-eslint/no-redeclare from config

### DIFF
--- a/toolchain/eslint-config/configs/typescript.js
+++ b/toolchain/eslint-config/configs/typescript.js
@@ -33,7 +33,6 @@ export default config(
       '@typescript-eslint/no-deprecated': 'error',
       '@typescript-eslint/no-import-type-side-effects': 'error',
       '@typescript-eslint/no-non-null-assertion': 'error',
-      '@typescript-eslint/no-redeclare': 'error',
       '@typescript-eslint/no-shadow': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',


### PR DESCRIPTION
The code problem checked by this ESLint
rule is automatically checked by the
TypeScript compiler. Thus, it is not
recommended to turn on this rule in new
TypeScript projects.