### PR TITLE
refactor(apps/effect-api-server): split execution from definition

### DIFF
--- a/apps/effect-api-server/src/http.ts
+++ b/apps/effect-api-server/src/http.ts
@@ -1,0 +1,33 @@
+import {
+  HttpApiBuilder,
+  HttpApiScalar,
+  HttpMiddleware,
+  HttpServer,
+  PlatformConfigProvider,
+} from '@effect/platform'
+import { NodeFileSystem, NodeHttpServer } from '@effect/platform-node'
+import { Effect, Layer } from 'effect'
+import { createServer } from 'node:http'
+
+import { ApiLive } from '@packages/api-impl'
+import { DatabaseLive } from '@packages/api-impl/services'
+import { Database } from '@packages/db-drizzlepg/effect-client'
+
+const EnvProviderLayer = Layer.unwrapEffect(
+  PlatformConfigProvider.fromDotEnv('.env').pipe(
+    Effect.andThen(Layer.setConfigProvider),
+    Effect.provide(NodeFileSystem.layer),
+  ),
+)
+
+export const HttpLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+  Layer.merge(Layer.effectDiscard(Database.Database.use((db) => db.setupConnectionListeners))),
+  Layer.provide(DatabaseLive),
+  Layer.provide(HttpApiScalar.layer({ scalar: { layout: 'modern', theme: 'kepler' } })),
+  Layer.provide(HttpApiBuilder.middlewareOpenApi()),
+  Layer.provide(HttpApiBuilder.middlewareCors()),
+  Layer.provide(ApiLive),
+  Layer.provide(EnvProviderLayer),
+  HttpServer.withLogAddress,
+  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 })),
+)

--- a/apps/effect-api-server/src/index.ts
+++ b/apps/effect-api-server/src/index.ts
@@ -1,39 +1,10 @@
-import {
-  HttpApiBuilder,
-  HttpApiScalar,
-  HttpMiddleware,
-  HttpServer,
-  PlatformConfigProvider,
-} from '@effect/platform'
-import { NodeFileSystem, NodeHttpServer, NodeRuntime } from '@effect/platform-node'
+import { NodeRuntime } from '@effect/platform-node'
 import { Duration, Effect, Layer, Schedule } from 'effect'
-import { createServer } from 'node:http'
 
-import { ApiLive } from '@packages/api-impl'
-import { DatabaseLive } from '@packages/api-impl/services'
-import { Database } from '@packages/db-drizzlepg/effect-client'
+import { HttpLive } from './http.js'
 
-const EnvProviderLayer = Layer.unwrapEffect(
-  PlatformConfigProvider.fromDotEnv('.env').pipe(
-    Effect.andThen(Layer.setConfigProvider),
-    Effect.provide(NodeFileSystem.layer),
-  ),
-)
-
-const HttpLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
-  // TODO: Ideally there should not require a dependency on @packages/db-drizzlepg
-  //       and required setupConnection should not be a concern of the api server
-  Layer.merge(Layer.effectDiscard(Database.Database.use((db) => db.setupConnectionListeners))),
-  Layer.provide(DatabaseLive),
-  Layer.provide(HttpApiScalar.layer({ scalar: { layout: 'modern', theme: 'kepler' } })),
-  Layer.provide(HttpApiBuilder.middlewareOpenApi()),
-  Layer.provide(ApiLive),
-  Layer.provide(EnvProviderLayer),
-  HttpServer.withLogAddress,
-  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 })),
-)
-
-Layer.launch(HttpLive).pipe(
+HttpLive.pipe(
+  Layer.launch,
   Effect.tapErrorCause(Effect.logError),
   Effect.retry({
     schedule: Schedule.exponential('1 second', 2).pipe(
@@ -51,5 +22,5 @@ Layer.launch(HttpLive).pipe(
     ),
     while: (error) => error._tag === 'DatabaseConnectionLostError',
   }),
-  NodeRuntime.runMain,
+  NodeRuntime.runMain({ disableErrorReporting: true }),
 )


### PR DESCRIPTION
https.ts contains the building of the
http layer while index.ts contains the
node runtime execution