### PR TITLE
refactor(apps/sveltekit-example-app): change how tsconfig.json is extended

### DIFF
--- a/apps/sveltekit-example-app/eslint.config.js
+++ b/apps/sveltekit-example-app/eslint.config.js
@@ -2,8 +2,6 @@ import config from '@toolchain/eslint-config/profile/svelte'
 
 import svelteConfig from './svelte.config.js'
 
-delete svelteConfig.kit.typescript.config
-
 export default [
   ...config,
   {

--- a/apps/sveltekit-example-app/svelte.config.js
+++ b/apps/sveltekit-example-app/svelte.config.js
@@ -8,12 +8,6 @@ const config = {
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
-    typescript: {
-      config: (config) => {
-        config['extends'] = '@toolchain/typescript-config/tsconfig-svelte.json'
-        return config
-      },
-    },
   },
   // Consult https://kit.svelte.dev/docs/integrations#preprocessors
   // for more information about preprocessors

--- a/apps/sveltekit-example-app/tsconfig.json
+++ b/apps/sveltekit-example-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
+  "extends": ["@toolchain/typescript-config/tsconfig-svelte.json", "./.svelte-kit/tsconfig.json"],
   "compilerOptions": {
     "types": ["vitest/globals"]
   }

--- a/packages/db-drizzlepg-client/eslint.config.js
+++ b/packages/db-drizzlepg-client/eslint.config.js
@@ -1,0 +1,15 @@
+import config from '@toolchain/eslint-config/profile/node'
+
+export default [
+  ...config,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      'unicorn/throw-new-error': 'off',
+    },
+  },
+]

--- a/packages/db-drizzlepg-client/package.json
+++ b/packages/db-drizzlepg-client/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@packages/db-drizzlepg-client",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Effectful Drizzle PostgreSQL client using node-postgres driver",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "clean": "del .turbo coverage",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@effect/platform": "0.84.4",
+    "@effect/platform-node": "0.84.2",
+    "drizzle-orm": "0.44.1",
+    "effect": "3.16.3",
+    "pg": "8.16.0"
+  },
+  "devDependencies": {
+    "@toolchain/eslint-config": "workspace:*",
+    "@toolchain/typescript-config": "workspace:*",
+    "@toolchain/vitest-config": "workspace:*",
+    "@types/pg": "8.15.2"
+  }
+}

--- a/packages/db-drizzlepg-client/src/index.test.ts
+++ b/packages/db-drizzlepg-client/src/index.test.ts
@@ -1,0 +1,29 @@
+import { Effect, Layer, ManagedRuntime, Redacted } from 'effect'
+
+import { DataSource, layer } from './index.js'
+
+describe('effectful queries', () => {
+  const mainLayer = Layer.mergeAll(
+    layer({
+      connectionString: Redacted.make('postgresql://postgres:postgres@localhost:5432/postgres'),
+      loggingEnabled: false,
+      ssl: false,
+    }),
+  )
+
+  const managedRuntime = ManagedRuntime.make(mainLayer)
+
+  it('should execute a query', async () => {
+    expect.assertions(0)
+
+    const main = Effect.gen(function* () {
+      const { db } = yield* DataSource
+      const result = yield* Effect.tryPromise(() => db.query('SELECT 1'))
+      yield* Effect.logError(JSON.stringify(result.rowCount, null, 2))
+    })
+
+    // await managedRuntime.runPromise(main.pipe(Effect.provide(mainLayer), Effect.scoped))
+    const res = await managedRuntime.runPromiseExit(main.pipe(Effect.provide(mainLayer)))
+    console.log(res)
+  })
+})

--- a/packages/db-drizzlepg-client/src/index.ts
+++ b/packages/db-drizzlepg-client/src/index.ts
@@ -1,0 +1,64 @@
+import { Context, Data, Effect, Layer, Redacted } from 'effect'
+import pg from 'pg'
+
+// see https://github.com/bmdavis419/notion-discord-notifications/blob/main/src/redis.ts
+//     https://github.com/bmdavis419/notion-discord-notifications/blob/main/src/redis.ts
+//     https://effect.website/play#7e9fe129bc61
+//     https://github.com/floydspace/effect-aws/blob/192aad72a154951e5814f12cae90cc3d1b63621c/packages/commons/src/ServiceLogger.ts#L65-L77
+
+export class DatabaseError extends Data.TaggedError('DatabaseError')<{
+  cause?: unknown
+  message?: string
+}> {}
+
+export interface PgClientConfig {
+  readonly connectionString: Redacted.Redacted
+  readonly loggingEnabled: boolean
+  readonly ssl: boolean
+}
+
+const scopedDbConnectionResource = Effect.fn(function* (config: PgClientConfig) {
+  return yield* Effect.acquireRelease(
+    Effect.sync(
+      () =>
+        new pg.Pool({
+          connectionString: Redacted.value(config.connectionString),
+          connectionTimeoutMillis: 0,
+          idleTimeoutMillis: 0,
+          ssl: config.ssl,
+        }),
+    ).pipe(
+      Effect.tap((connection) =>
+        Effect.tryPromise({
+          catch: (cause) =>
+            new DatabaseError({
+              cause,
+              message: '[DataSource] Failed to connect',
+            }),
+          try: () => connection.query('SELECT 1'),
+        }),
+      ),
+    ),
+    (connection) =>
+      Effect.promise(() => connection.end()).pipe(
+        Effect.tap(() => Effect.logInfo('[DataSource]: Connection closed.')),
+      ),
+  )
+})
+
+export class DataSource extends Context.Tag('DataSource')<
+  DataSource,
+  {
+    readonly db: pg.Pool
+  }
+>() {}
+
+// : Effect.Effect<pg.Pool, DatabaseError, Scope.Scope>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- todo
+const make = (config: PgClientConfig) =>
+  Effect.gen(function* () {
+    return { db: yield* scopedDbConnectionResource(config) }
+  })
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type,@typescript-eslint/explicit-module-boundary-types -- todo
+export const layer = (config: PgClientConfig) => Layer.scoped(DataSource, make(config))

--- a/packages/db-drizzlepg-client/tsconfig.json
+++ b/packages/db-drizzlepg-client/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@toolchain/typescript-config/tsconfig-node22.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/packages/db-drizzlepg-client/vitest.config.js
+++ b/packages/db-drizzlepg-client/vitest.config.js
@@ -1,0 +1,15 @@
+import { createRequire } from 'node:module'
+
+import sharedConfig, { defineConfig, mergeConfig } from '@toolchain/vitest-config'
+
+const require = createRequire(import.meta.url)
+const packageJson = require('./package.json')
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: packageJson.name,
+    },
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,37 @@ importers:
         specifier: 4.19.4
         version: 4.19.4
 
+  packages/db-drizzlepg-client:
+    dependencies:
+      '@effect/platform':
+        specifier: 0.84.4
+        version: 0.84.4(effect@3.16.3)
+      '@effect/platform-node':
+        specifier: 0.84.2
+        version: 0.84.2(@effect/cluster@0.29.21(@effect/platform@0.84.4(effect@3.16.3))(@effect/rpc@0.55.16(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(@effect/sql@0.33.11(@effect/experimental@0.44.11(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(effect@3.16.3))(@effect/platform@0.84.4(effect@3.16.3))(@effect/rpc@0.55.16(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(@effect/sql@0.33.11(@effect/experimental@0.44.11(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(@effect/platform@0.84.4(effect@3.16.3))(effect@3.16.3))(effect@3.16.3)
+      drizzle-orm:
+        specifier: 0.44.1
+        version: 0.44.1(@types/pg@8.15.2)(gel@2.0.0)(pg@8.16.0)
+      effect:
+        specifier: 3.16.3
+        version: 3.16.3
+      pg:
+        specifier: 8.16.0
+        version: 8.16.0
+    devDependencies:
+      '@toolchain/eslint-config':
+        specifier: workspace:*
+        version: link:../../toolchain/eslint-config
+      '@toolchain/typescript-config':
+        specifier: workspace:*
+        version: link:../../toolchain/typescript-config
+      '@toolchain/vitest-config':
+        specifier: workspace:*
+        version: link:../../toolchain/vitest-config
+      '@types/pg':
+        specifier: 8.15.2
+        version: 8.15.2
+
   packages/example-pkg:
     devDependencies:
       '@toolchain/eslint-config':


### PR DESCRIPTION
Previously was using an approach provided
via svelte.config.js. But this was always
a bit non-standard. TypeScript has had
support for extending multiple tsconfig.json 
files for a while now. This change favors
the latter approach.