### PR TITLE
feat(packages/api): add single item wrapper helper for structured response messages

### DIFF
--- a/packages/api-impl/src/tasks-live.ts
+++ b/packages/api-impl/src/tasks-live.ts
@@ -1,14 +1,16 @@
 import { HttpApiBuilder } from '@effect/platform'
 import { Effect } from 'effect'
 
-import { Api, TodoId } from '@packages/api'
+import { type Task, Api, TaskId, wrapSingleItemResponse } from '@packages/api'
 
 export const taskGroupLive = HttpApiBuilder.group(Api, 'tasks', (handlers) =>
   handlers.handle('getTaskById', ({ path }) =>
-    Effect.succeed({
-      id: TodoId.make(path.id),
-      done: false,
-      name: 'My Found Task',
-    }),
+    Effect.succeed(
+      wrapSingleItemResponse<Task>({
+        id: TaskId.make(path.id),
+        done: false,
+        name: 'My Found Task',
+      }),
+    ),
   ),
 )

--- a/packages/api/src/contracts/tasks-contract.ts
+++ b/packages/api/src/contracts/tasks-contract.ts
@@ -9,20 +9,15 @@ import { Schema } from 'effect'
 import status from 'http-status'
 
 import * as CustomHttpApiError from '../custom-httpapi-error.js'
-import { TodoId } from '../entity-ids.js'
-
-export class Task extends Schema.Class<Task>('Task')({
-  id: TodoId,
-  done: Schema.Boolean,
-  name: Schema.NonEmptyTrimmedString,
-}) {}
+import { Task } from '../domain.js'
+import { singleItemResponseWrapperSchema } from '../response-helpers.js'
 
 export const UuidParamSchema = HttpApiSchema.param('id', Schema.UUID)
 
 export class ApiGroup extends HttpApiGroup.make('tasks') //
   .add(
     HttpApiEndpoint.get('getTaskById')`/${UuidParamSchema}`
-      .addSuccess(Task, { status: status.OK })
+      .addSuccess(singleItemResponseWrapperSchema(Task), { status: status.OK })
       .addError(CustomHttpApiError.BadRequest)
       .addError(HttpApiError.HttpApiDecodeError)
       .addError(CustomHttpApiError.NotFound),

--- a/packages/api/src/domain.ts
+++ b/packages/api/src/domain.ts
@@ -1,0 +1,10 @@
+import { Schema } from 'effect'
+
+export const TaskId = Schema.UUID.pipe(Schema.brand('TaskId'))
+export type TaskId = typeof TaskId.Type
+
+export class Task extends Schema.Class<Task>('Task')({
+  id: TaskId,
+  done: Schema.Boolean,
+  name: Schema.NonEmptyTrimmedString,
+}) {}

--- a/packages/api/src/entity-ids.ts
+++ b/packages/api/src/entity-ids.ts
@@ -1,4 +1,0 @@
-import { Schema } from 'effect'
-
-export const TodoId = Schema.UUID.pipe(Schema.brand('TodoId'))
-export type TodoId = typeof TodoId.Type

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,2 +1,3 @@
 export { Api } from './api.js'
-export * from './entity-ids.js'
+export * from './domain.js'
+export * from './response-helpers.js'

--- a/packages/api/src/response-helpers.ts
+++ b/packages/api/src/response-helpers.ts
@@ -1,0 +1,22 @@
+import { Schema } from 'effect'
+
+export interface SingleItemResponseWrapper<T> {
+  readonly data: T
+  readonly success: true
+  readonly timestamp: string
+}
+
+export const singleItemResponseWrapperSchema = <A, I, R>(
+  itemSchema: Schema.Schema<A, I, R>,
+): Schema.Schema<SingleItemResponseWrapper<A>, SingleItemResponseWrapper<I>, R> =>
+  Schema.Struct({
+    data: itemSchema,
+    success: Schema.Literal(true),
+    timestamp: Schema.String,
+  })
+
+export const wrapSingleItemResponse = <T>(item: T): SingleItemResponseWrapper<T> => ({
+  data: item,
+  success: true,
+  timestamp: new Date().toISOString(),
+})


### PR DESCRIPTION


APIs that return a single item are wrapped in
a standard message structure to allow for
additional metadata about the response both now
and in the future.