### PR TITLE
feat(toolchain/eslint-config): add and config eslint-plugin-turbo

### DIFF
--- a/apps/hono-api-server/turbo.json
+++ b/apps/hono-api-server/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["NODE_ENV"]
+    }
+  }
+}

--- a/packages/api-hono/turbo.json
+++ b/packages/api-hono/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["NODE_ENV"]
+    }
+  }
+}

--- a/packages/db-drizzlepg/turbo.json
+++ b/packages/db-drizzlepg/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["DB_CONNECTION_STRING"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       eslint-plugin-svelte:
         specifier: 3.10.1
         version: 3.10.1(eslint@9.31.0(jiti@2.4.2))(svelte@5.36.0)(ts-node@10.9.2(@types/node@24.0.3)(typescript@5.8.3))
+      eslint-plugin-turbo:
+        specifier: 2.5.4
+        version: 2.5.4(eslint@9.31.0(jiti@2.4.2))(turbo@2.5.4)
       eslint-plugin-unicorn:
         specifier: 59.0.1
         version: 59.0.1(eslint@9.31.0(jiti@2.4.2))
@@ -2695,6 +2698,10 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  dotenv@16.0.3:
+    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
+
   dotenv@17.2.0:
     resolution: {integrity: sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==}
     engines: {node: '>=12'}
@@ -3008,6 +3015,12 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
+
+  eslint-plugin-turbo@2.5.4:
+    resolution: {integrity: sha512-IZsW61DFj5mLMMaCJxhh1VE4HvNhfdnHnAaXajgne+LUzdyHk2NvYT0ECSa/1SssArcqgTvV74MrLL68hWLLFw==}
+    peerDependencies:
+      eslint: '>6.6.0'
+      turbo: '>2.0.0'
 
   eslint-plugin-unicorn@59.0.1:
     resolution: {integrity: sha512-EtNXYuWPUmkgSU2E7Ttn57LbRREQesIP1BiLn7OZLKodopKfDXfBUkC/0j6mpw2JExwf43Uf3qLSvrSvppgy8Q==}
@@ -7632,6 +7645,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv@16.0.3: {}
+
   dotenv@17.2.0: {}
 
   drizzle-dbml-generator@0.10.0(drizzle-orm@0.44.3(@opentelemetry/api@1.9.0)(@types/pg@8.15.4)(gel@2.0.0)(pg@8.16.3)):
@@ -7976,6 +7991,12 @@ snapshots:
       svelte: 5.36.0
     transitivePeerDependencies:
       - ts-node
+
+  eslint-plugin-turbo@2.5.4(eslint@9.31.0(jiti@2.4.2))(turbo@2.5.4):
+    dependencies:
+      dotenv: 16.0.3
+      eslint: 9.31.0(jiti@2.4.2)
+      turbo: 2.5.4
 
   eslint-plugin-unicorn@59.0.1(eslint@9.31.0(jiti@2.4.2)):
     dependencies:

--- a/toolchain/eslint-config/configs/base.js
+++ b/toolchain/eslint-config/configs/base.js
@@ -1,6 +1,7 @@
 import { config } from 'typescript-eslint'
 
 import eslintCommentsConfig from './js/eslint-comments.js'
+import turborepo from './turborepo.js'
 
 export default config(
   {
@@ -21,4 +22,5 @@ export default config(
     },
   },
   eslintCommentsConfig,
+  turborepo,
 )

--- a/toolchain/eslint-config/configs/turborepo.js
+++ b/toolchain/eslint-config/configs/turborepo.js
@@ -1,0 +1,12 @@
+import turbo from 'eslint-plugin-turbo'
+
+export default [
+  {
+    plugins: {
+      turbo,
+    },
+    rules: {
+      'turbo/no-undeclared-env-vars': 'error',
+    },
+  },
+]

--- a/toolchain/eslint-config/package.json
+++ b/toolchain/eslint-config/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-svelte": "3.10.1",
+    "eslint-plugin-turbo": "2.5.4",
     "eslint-plugin-unicorn": "59.0.1",
     "typescript-eslint": "8.37.0"
   },


### PR DESCRIPTION
This eslint plugin ensures that the task
cache is busted in dependent env vars are
changed. In other words, you don't want
to cache a task that can potentially have
different behavior in a different
environment.