### PR TITLE
refactor(packages/ui-lib-svelte): change how tsconfig.json is extended

### DIFF
--- a/packages/ui-lib-svelte/svelte.config.js
+++ b/packages/ui-lib-svelte/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-node'
+import adapter from '@sveltejs/adapter-auto'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/packages/ui-lib-svelte/svelte.config.js
+++ b/packages/ui-lib-svelte/svelte.config.js
@@ -1,19 +1,13 @@
-import adapter from '@sveltejs/adapter-auto'
+import adapter from '@sveltejs/adapter-node'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-    // If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+    // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
-    typescript: {
-      config: (config) => {
-        config['extends'] = '@toolchain/typescript-config/tsconfig-svelte.json'
-        return config
-      },
-    },
   },
   // Consult https://kit.svelte.dev/docs/integrations#preprocessors
   // for more information about preprocessors

--- a/packages/ui-lib-svelte/tsconfig.json
+++ b/packages/ui-lib-svelte/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
+  "extends": ["@toolchain/typescript-config/tsconfig-svelte.json", "./.svelte-kit/tsconfig.json"],
   "compilerOptions": {
     "types": ["vitest/globals"]
   }


### PR DESCRIPTION
Previously was using an approach provided
via svelte.config.js. But this was always
a bit non-standard. TypeScript has had
support for extending multiple tsconfig.json
files for a while now. This change favors
the latter approach.