### PR TITLE
chore(monorepo): update minimum node version to 22.18.0 in package.json / engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
   "engines": {
-    "node": ">= 22.14.x < 23.x.x"
+    "node": ">= 22.18.x < 23.x.x"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Node 22.18 has Type stripping enabled
by default now which executes TypeScript
files without additional configuration.