### PR TITLE
refactor(packages/ui-lib-svelte): move some libraries from `devDependencies` to dependencies

### DIFF
--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -17,7 +17,6 @@
     "pg": "8.16.3"
   },
   "devDependencies": {
-    "@lucide/svelte": "0.539.0",
     "@packages/ui-lib-svelte": "workspace:*",
     "@sveltejs/adapter-node": "5.2.14",
     "@sveltejs/kit": "2.29.1",
@@ -26,7 +25,6 @@
     "@toolchain/eslint-config": "workspace:*",
     "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
-    "bits-ui": "2.9.3",
     "effect": "3.17.7",
     "http-status-codes": "2.3.0",
     "mode-watcher": "1.1.0",

--- a/packages/ui-lib-svelte/package.json
+++ b/packages/ui-lib-svelte/package.json
@@ -20,8 +20,12 @@
     "test": "vitest run",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json"
   },
-  "devDependencies": {
+  "dependencies": {
     "@lucide/svelte": "0.539.0",
+    "bits-ui": "2.9.3",
+    "svelte-sonner": "1.0.5"
+  },
+  "devDependencies": {
     "@sveltejs/adapter-auto": "6.1.0",
     "@sveltejs/kit": "2.29.1",
     "@sveltejs/vite-plugin-svelte": "6.1.2",
@@ -29,12 +33,10 @@
     "@toolchain/eslint-config": "workspace:*",
     "@toolchain/typescript-config": "workspace:*",
     "@toolchain/vitest-config": "workspace:*",
-    "bits-ui": "2.9.3",
     "clsx": "2.1.1",
     "mode-watcher": "1.1.0",
     "svelte": "5.38.1",
     "svelte-check": "4.3.1",
-    "svelte-sonner": "1.0.5",
     "tailwind-merge": "3.3.1",
     "tailwind-variants": "2.1.0",
     "tailwindcss": "4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,9 +221,6 @@ importers:
         specifier: 8.16.3
         version: 8.16.3
     devDependencies:
-      '@lucide/svelte':
-        specifier: 0.539.0
-        version: 0.539.0(svelte@5.38.1)
       '@packages/ui-lib-svelte':
         specifier: workspace:*
         version: link:../../packages/ui-lib-svelte
@@ -248,9 +245,6 @@ importers:
       '@toolchain/vitest-config':
         specifier: workspace:*
         version: link:../../toolchain/vitest-config
-      bits-ui:
-        specifier: 2.9.3
-        version: 2.9.3(@internationalized/date@3.8.2)(svelte@5.38.1)
       effect:
         specifier: 3.17.7
         version: 3.17.7
@@ -497,10 +491,17 @@ importers:
         version: 4.20.4
 
   packages/ui-lib-svelte:
-    devDependencies:
+    dependencies:
       '@lucide/svelte':
         specifier: 0.539.0
         version: 0.539.0(svelte@5.38.1)
+      bits-ui:
+        specifier: 2.9.3
+        version: 2.9.3(@internationalized/date@3.8.2)(svelte@5.38.1)
+      svelte-sonner:
+        specifier: 1.0.5
+        version: 1.0.5(svelte@5.38.1)
+    devDependencies:
       '@sveltejs/adapter-auto':
         specifier: 6.1.0
         version: 6.1.0(@sveltejs/kit@2.29.1(@sveltejs/vite-plugin-svelte@6.1.2(svelte@5.38.1)(vite@7.1.2(@types/node@24.2.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)))(svelte@5.38.1)(vite@7.1.2(@types/node@24.2.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)))
@@ -522,9 +523,6 @@ importers:
       '@toolchain/vitest-config':
         specifier: workspace:*
         version: link:../../toolchain/vitest-config
-      bits-ui:
-        specifier: 2.9.3
-        version: 2.9.3(@internationalized/date@3.8.2)(svelte@5.38.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -537,9 +535,6 @@ importers:
       svelte-check:
         specifier: 4.3.1
         version: 4.3.1(picomatch@4.0.3)(svelte@5.38.1)(typescript@5.9.2)
-      svelte-sonner:
-        specifier: 1.0.5
-        version: 1.0.5(svelte@5.38.1)
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1


### PR DESCRIPTION
Moving to dependencies allows for upstream projects to 
not have to add these dependencies by default.