### PR TITLE
ci(github-actions): guard docker build on fork prs and add cleanup safety margin

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,8 +27,12 @@ jobs:
   # ─────────────────────────────────────────────
   docker-build:
     needs: [code-quality, affected]
-    # Only build the image when its app (or one of its deps) is affected.
-    if: contains(fromJSON(needs.affected.outputs.packages), '@apps/effect-api-server')
+    # Only build the image when its app (or one of its deps) is affected, and
+    # never for fork PRs: the staging pipeline pushes per-arch digests to GHCR,
+    # but fork PRs receive a read-only GITHUB_TOKEN and would fail on push.
+    if: >-
+      contains(fromJSON(needs.affected.outputs.packages), '@apps/effect-api-server')
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     permissions:
       attestations: write
       contents: read

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -54,6 +54,11 @@ jobs:
           # Delete dangling manifests; multi-arch children + attestations that
           # belong to a tagged image are preserved automatically.
           delete-untagged: true
+          # Safety margin against the build race: a multi-arch build pushes
+          # per-arch child digests (briefly untagged/unreferenced) before the
+          # merge job tags the index. Never prune anything newer than this so a
+          # cleanup run can't delete an in-flight build's children.
+          older-than: 1 day
           # Re-link and verify multi-arch/referrer integrity after deletion.
           validate: true
           # Scheduled runs delete for real; manual runs default to a preview.


### PR DESCRIPTION
## Summary

Two low-risk, behavior-narrowing hardening fixes to the CI/CD workflows.

### 1. Fork-PR guard on `docker-build` (`ci-cd.yml`)
The staging pipeline pushes per-arch digests to GHCR, but PRs from forks receive a read-only `GITHUB_TOKEN` and would fail on push. The `docker-build` job now additionally requires the PR not originate from a fork:

```yaml
if: >-
  contains(fromJSON(needs.affected.outputs.packages), '@apps/effect-api-server')
  && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
```

- Internal PRs and pushes to `main` are unaffected.
- Fork PRs that touch the API now **skip** the build/push pipeline instead of failing.
- The `ci-passed` aggregate gate treats a skip as a pass, so fork PRs are not blocked.

### 2. Cleanup safety margin (`ghcr-cleanup.yml`)
A multi-arch build pushes per-arch child digests (briefly untagged/unreferenced) before the `merge` job tags the manifest index. Added `older-than: 1 day` so a scheduled prune cannot delete an in-flight build's children during that window.

## Testing
- `actionlint` (via Docker) reports no new findings.
- Validation of `older-than` parsing can be confirmed via a `workflow_dispatch` run of `ghcr-cleanup` with `dry_run: true`.

## Notes
Branch protection should require only the `ci-passed` check (added previously) so conditionally-skipped jobs — including fork-PR builds — don't block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)