### PR TITLE
ci(github-actions): tighten root permissions, fix main concurrency and stale scan docs

### DIFF
--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -1,16 +1,17 @@
 # =============================================================================
 # Reusable Workflow: Docker Security Scan
 # =============================================================================
-# Downloads a Docker image artifact, runs Trivy and Grype vulnerability
-# scanners, uploads SARIF to GitHub Security tab, and gates on severity.
+# Pulls a Docker image from GHCR by its pinned ref, runs Trivy (vuln, secret,
+# and misconfig scanners), uploads SARIF to the GitHub Security tab, and gates
+# the build on the configured severity threshold.
 #
 # Usage:
 #   jobs:
 #     scan:
 #       uses: ./.github/workflows/_docker-security-scan.yml
 #       with:
-#         artifact_name: docker-image
-#         fail_on_severity: CRITICAL
+#         image_ref: ghcr.io/owner/name@sha256:...
+#         severity_threshold: CRITICAL
 # =============================================================================
 
 name: Docker Security Scan

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,10 +8,17 @@ on:
     branches: [main]
     tags-ignore: ['**']
 
-# Cancel superseded runs on the same ref (e.g. new pushes to a PR)
+# Cancel superseded PR runs on the same ref (e.g. new pushes to a PR), but let
+# main builds run to completion — they push images, attestations, and tags that
+# must not be interrupted mid-publish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Default-deny at the workflow root; jobs that need more elevate per job.
+# contents: read is the minimum for affected/code-quality to check out the repo.
+permissions:
+  contents: read
 
 jobs:
   # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three low-risk workflow hygiene fixes (review items #4, #7, #8).

### #7 — Default-deny permissions at the `ci-cd` root
Adds `permissions: contents: read` at the workflow level so nothing inherits broad repository token defaults. `contents: read` is the minimum needed for the `affected` and `code-quality` jobs to check out the repo; `docker-build` and `scan` already declare their own elevated per-job permissions, which override the root.

### #8 — Don't cancel in-progress `main` builds
`cancel-in-progress` now applies only to `pull_request` runs:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A push to `main` publishes images, attestations, and tags — cancelling it mid-publish could leave a partially-pushed manifest. PRs still cancel superseded runs as before.

### #4 — Fix stale docs in `_docker-security-scan.yml`
The header claimed it "downloads a Docker image artifact" and runs "Trivy **and Grype**", and the usage example referenced non-existent `artifact_name`/`fail_on_severity` inputs. Updated to reflect reality: it pulls from GHCR by ref, runs Trivy only, and takes `image_ref`/`severity_threshold`.

## Testing
- `actionlint` (via Docker) reports no new findings.
- Permissions change is a strict tightening; verified every job either inherits the sufficient `contents: read` (affected, code-quality, ci-passed) or sets its own job-level permissions (docker-build, scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)