### PR TITLE
ci(github-actions): fix monorepo-health blocking merges on unrelated prs

### DIFF
--- a/.github/workflows/monorepo-health.yml
+++ b/.github/workflows/monorepo-health.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-    paths:
-      - 'pnpm-lock.yaml'
-      - 'package.json'
-      - '**/package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,10 +13,45 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether any dependency manifests changed so the health checks below
+  # can be skipped on runs that don't touch package files. Reuses TURBO_SCM_BASE
+  # and TURBO_SCM_HEAD set by prepare, so the diff range is consistent with what
+  # turbo --affected uses in the main ci-cd workflow.
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      deps-changed: ${{ steps.filter.outputs.deps }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare
+        uses: ./.github/composite-actions/prepare
+
+      - name: Detect dependency file changes
+        id: filter
+        run: |
+          set -euo pipefail
+          if git diff --name-only "$TURBO_SCM_BASE" "$TURBO_SCM_HEAD" | grep -qE '(^|/)package\.json$|^pnpm-lock\.yaml$'; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deps=false" >> "$GITHUB_OUTPUT"
+          fi
+
   one-version-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.deps-changed == 'true'
     name: One Version Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: Check out code
@@ -33,9 +64,13 @@ jobs:
         run: pnpm run one-version:check
 
   duplicate-dependencies-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.deps-changed == 'true'
     name: Duplicate Dependencies Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: Check out code
@@ -46,3 +81,21 @@ jobs:
 
       - name: Check for Duplicate Dependencies
         run: pnpm dedupe --check
+
+  # Single aggregate status check — configure branch protection to require ONLY
+  # this job. Health checks skipped because no dep files changed still count as
+  # passing; actual failures and cancellations fail the gate.
+  monorepo-health-passed:
+    if: always()
+    needs: [detect-changes, one-version-check, duplicate-dependencies-check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify health checks passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more monorepo health checks failed or were cancelled."
+            exit 1
+          fi
+          echo "Monorepo health checks passed (skipped checks are allowed)."


### PR DESCRIPTION
## Summary

Fixes `monorepo-health` blocking PR merges when no dependency files changed.

The previous trigger-level `paths` filter caused `one-version-check` and `duplicate-dependencies-check` to be **skipped** on non-matching PRs. GitHub treats a skipped required status check the same as a failure, so every docs or app-source-only PR was blocked from merging.

**Changes:**
- Remove `paths` filter from the `pull_request` trigger so the workflow always runs
- Add a `detect-changes` job that diffs `package.json` and `pnpm-lock.yaml` using `TURBO_SCM_BASE`/`TURBO_SCM_HEAD` from the `prepare` composite action — same range `turbo --affected` uses
- Gate `one-version-check` and `duplicate-dependencies-check` on the `detect-changes` output
- Add a `monorepo-health-passed` aggregate job (mirrors the `ci-passed` pattern in `ci-cd.yml`) that always runs and passes when health checks are skipped

## Branch protection update required

Replace `one-version-check` and `duplicate-dependencies-check` as required status checks with `monorepo-health-passed`.

## Test plan

- [ ] Open a PR touching only app source — confirm `one-version-check` and `duplicate-dependencies-check` are **skipped**, `monorepo-health-passed` goes **green**, merge is not blocked
- [ ] Open a PR touching `pnpm-lock.yaml` or a `package.json` — confirm both health check jobs run and `monorepo-health-passed` reflects their outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)