### PR TITLE
fix(github-actions): friendly error when release image_tag is missing

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -101,9 +101,16 @@ jobs:
           [[ -n "$IMAGE_NAME" ]] || { echo "::error::$cfg is missing the required \"imageName\" field"; exit 1; }
           REPO="$REGISTRY/$IMAGE_NAME"
 
-          GIT_SHA=$(docker buildx imagetools inspect "$REPO:$IMAGE_TAG" --format '{{json .}}' \
-            | jq -r '[.. | objects | select(has("org.opencontainers.image.revision"))
-                      | .["org.opencontainers.image.revision"]] | first // empty')
+          # Capture inspect separately so a missing tag yields a friendly error
+          # rather than aborting the step on docker's own "not found" (set -e +
+          # pipefail would kill the command substitution before we can check).
+          if ! MANIFEST=$(docker buildx imagetools inspect "$REPO:$IMAGE_TAG" --format '{{json .}}' 2>/dev/null); then
+            echo "::error::Image $REPO:$IMAGE_TAG not found in ECR — check the image_tag input"
+            exit 1
+          fi
+
+          GIT_SHA=$(jq -r '[.. | objects | select(has("org.opencontainers.image.revision"))
+                            | .["org.opencontainers.image.revision"]] | first // empty' <<< "$MANIFEST")
 
           if [[ -z "$GIT_SHA" ]]; then
             echo "::error::org.opencontainers.image.revision label not found in $REPO:$IMAGE_TAG — was this image built by this pipeline?"


### PR DESCRIPTION
## Summary

- When a non-existent `image_tag` is passed to Cut Release, the resolve step aborted on docker's raw `ERROR: ...:<tag>: not found` (because `set -e` + `pipefail` kills the command substitution) instead of the intended friendly guard
- Capture the `imagetools inspect` result and check its exit code explicitly, so a bad tag now surfaces a clear message pointing at the `image_tag` input

## Context

Follow-up to #539. Observed in [this run](https://github.com/mpellegrini/fullstack-typescript-monorepo-starter/actions/runs/28491025484/job/84447531645) where `image_tag: sha-123` produced an opaque error.

## Test plan

- [ ] Trigger with a non-existent `image_tag` and confirm the friendly "Image ... not found in ECR — check the image_tag input" error
- [ ] Trigger with a valid `image_tag` (e.g. `latest`) and confirm resolution still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)