### PR TITLE
Switch release workflow to GitHub App auth and add release-deploy trigger

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -1,4 +1,4 @@
-# Cut a correctly tagged release from the Actions UI instead of
+# Create a correctly tagged release from the Actions UI instead of
 # hand-typing tags in the Releases page. Guarantees tag format
 # and prevents duplicate versions.
 #
@@ -12,7 +12,7 @@
 # be an ancestor of main, so pr-* images (built from unmerged branches) are
 # rejected. Release latest or a sha-* tag from a merged commit.
 
-name: cut-release
+name: release-create
 
 on:
   workflow_dispatch:
@@ -155,9 +155,17 @@ jobs:
             echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Create release (triggers release-deploy.yml)
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }} # PAT/GitHub App token so the release event fires
+          # App token (not the default GITHUB_TOKEN) so the release event fires downstream
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP: ${{ inputs.app }}
           VERSION: ${{ inputs.version }}
           GIT_SHA: ${{ steps.image-info.outputs.git_sha }}

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,0 +1,42 @@
+# Fires when release-create.yml creates a GitHub release (gh release create).
+# Placeholder: only echoes the release payload for now — deployment logic
+# gets wired in on top of this once the trigger is confirmed working.
+
+name: release-deploy
+
+on:
+  release:
+    types: [released, prereleased]
+
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Echo release payload
+        # Passed via env (never inlined into the script) so a release name/body
+        # containing shell metacharacters can't inject commands.
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          TARGET_SHA: ${{ github.event.release.target_commitish }}
+          NAME: ${{ github.event.release.name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+          echo "tag: $TAG"
+          echo "target_commitish (git sha): $TARGET_SHA"
+          echo "name: $NAME"
+          echo "prerelease: $PRERELEASE"
+          echo "url: $URL"
+
+      - name: Echo parsed app/version from tag
+        # release-create.yml tags releases as "$APP@v$VERSION"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          APP="${TAG%@v*}"
+          VERSION="${TAG##*@v}"
+          echo "app: $APP"
+          echo "version: $VERSION"


### PR DESCRIPTION
## Summary
- Renames `cut-release.yml` → `release-create.yml` for clarity now that a `release-deploy.yml` counterpart exists
- Replaces the PAT-based `GH_TOKEN` with a short-lived GitHub App installation token (`actions/create-github-app-token`) so releases aren't tied to a personal account and don't need manual rotation, while still firing the `release` event that `release-deploy.yml` listens for
- Adds `release-deploy.yml`, triggered on `release: types: [released, prereleased]`, which for now just echoes the release payload (tag, target sha, prerelease flag, parsed app/version) to confirm the trigger works before real deploy logic is added

## Test plan
- [ ] Run `release-create` from the Actions UI for a test app/version
- [ ] Confirm `release-deploy` fires automatically and echoes the expected tag/sha/app/version values
- [ ] Confirm the GitHub App token (not a personal PAT) is what's used, per the Actions run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)