### PR TITLE
fix(github-actions): use client-id instead of deprecated app-id for app token

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -159,7 +159,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Create release (triggers release-deploy.yml)


### PR DESCRIPTION
## Summary
- The latest `release-create` run (https://github.com/mpellegrini/fullstack-typescript-monorepo-starter/actions/runs/28517779744) surfaced a deprecation warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`
- Switches the `actions/create-github-app-token` step in `release-create.yml` to use `client-id: ${{ vars.RELEASE_BOT_APP_CLIENT_ID }}` instead of the deprecated `app-id`
- The old `RELEASE_BOT_APP_ID` repo variable has been deleted; the new `RELEASE_BOT_APP_CLIENT_ID` variable is already set

Note: that same run also failed with `HTTP 403: Resource not accessible by integration` when creating the release — that's a separate issue in the GitHub App's Contents permission/installation approval, not fixable in workflow code. Tracked separately; needs to be corrected in the App's settings before the next release-create run.

## Test plan
- [ ] Re-run `release-create` after the App's Contents permission/installation approval is fixed
- [ ] Confirm no `app-id` deprecation warning appears in the run log
- [ ] Confirm the release is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)