### PR TITLE
ci(github-actions): pin actions to commit shas and remove manual dispatch

### DIFF
--- a/.github/composite-actions/prepare/action.yml
+++ b/.github/composite-actions/prepare/action.yml
@@ -36,11 +36,12 @@ runs:
       run: |
         set -euo pipefail
 
-        # The first push to a branch reports an all-zero "before" SHA: there is
-        # no prior commit to diff against. Fall back to the git empty-tree hash,
-        # which diffs every file as added and forces Turbo to treat all packages
-        # as affected (i.e. run everything).
-        if [[ "${RESOLVED_BASE}" == "0000000000000000000000000000000000000000" ]]; then
+        # The first push to a branch reports an all-zero "before" SHA, and
+        # workflow_dispatch has no "before" at all (empty): in both cases there
+        # is no prior commit to diff against. Fall back to the git empty-tree
+        # hash, which diffs every file as added and forces Turbo to treat all
+        # packages as affected (i.e. run everything).
+        if [[ -z "${RESOLVED_BASE}" || "${RESOLVED_BASE}" == "0000000000000000000000000000000000000000" ]]; then
           RESOLVED_BASE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         fi
 

--- a/.github/composite-actions/prepare/action.yml
+++ b/.github/composite-actions/prepare/action.yml
@@ -5,12 +5,12 @@ runs:
   using: composite
   steps:
     - name: Install pnpm package manager
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         run_install: false # Don't install yet, let caching work first
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: package.json
         cache: pnpm

--- a/.github/composite-actions/prepare/action.yml
+++ b/.github/composite-actions/prepare/action.yml
@@ -37,10 +37,11 @@ runs:
         set -euo pipefail
 
         # The first push to a branch reports an all-zero "before" SHA, and
-        # workflow_dispatch has no "before" at all (empty): in both cases there
-        # is no prior commit to diff against. Fall back to the git empty-tree
-        # hash, which diffs every file as added and forces Turbo to treat all
-        # packages as affected (i.e. run everything).
+        # triggers without a push payload (schedule/dispatch-style events)
+        # have no "before" at all (empty): in both cases there is no prior
+        # commit to diff against. Fall back to the git empty-tree hash, which
+        # diffs every file as added and forces Turbo to treat all packages as
+        # affected (i.e. run everything).
         if [[ -z "${RESOLVED_BASE}" || "${RESOLVED_BASE}" == "0000000000000000000000000000000000000000" ]]; then
           RESOLVED_BASE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         fi

--- a/.github/workflows/_code-quality.yml
+++ b/.github/workflows/_code-quality.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/_compute-affected-packages.yml
+++ b/.github/workflows/_compute-affected-packages.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Full history is required, so Turborepo can diff against the base ref.
           fetch-depth: 0

--- a/.github/workflows/_compute-deployable-apps.yml
+++ b/.github/workflows/_compute-deployable-apps.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Compute deployable affected apps
         id: compute

--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Need the PR head commit (a parent of the merge ref) available
           # locally so `git show` can read its committer date for BUILD_DATE.
@@ -71,14 +71,14 @@ jobs:
         uses: ./.github/composite-actions/resolve-commit-info
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       # The ECR repository (with its lifecycle rules, scan config, and policies)
       # must be provisioned out-of-band via IaC — CI does NOT create it. Verify it
@@ -100,14 +100,14 @@ jobs:
           echo "repo=${{ steps.ecr-login.outputs.registry }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       # Labels only (no tags here). The per-arch images are pushed by their digest,
       # so the full label set gets baked into each platform's image config. The
       # 'publish' job recomputes the same metadata to tag the final manifest.
       - name: Compute labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ steps.repo.outputs.repo }}
           labels: |
@@ -125,7 +125,7 @@ jobs:
       # per-platform digests into a single tagged multi-arch manifest.
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -152,7 +152,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ inputs.app_slug }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*

--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -53,21 +53,21 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       # Resolve this app's per-arch image refs from its digest artifacts. Each
       # artifact holds a single empty file named after the digest hex (no
       # sha256: prefix). Under a matrix, sibling apps upload their own
       # `digests-<app>-*` artifacts, so the pattern is scoped to this app.
       - name: Download digest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-${{ inputs.app_slug }}-*
@@ -90,7 +90,7 @@ jobs:
       # enough for visibility/triage.
       # -------------------------------------------------------------------
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           # Each digest is an attestation index (provenance/SBOM), so Trivy must
           # be told which child to scan instead of defaulting to the host arch.
@@ -104,7 +104,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: always() && hashFiles('trivy-results.sarif') != '' # Upload results even if the scan fails
         with:
           sarif_file: 'trivy-results.sarif'
@@ -115,7 +115,7 @@ jobs:
       # -------------------------------------------------------------------
       - name: Fail on ${{ inputs.severity_threshold }} vulnerabilities in amd64
         id: trivy-vuln-amd64
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/amd64
         with:
@@ -132,7 +132,7 @@ jobs:
       # -------------------------------------------------------------------
       - name: Fail on ${{ inputs.severity_threshold }} vulnerabilities in arm64
         id: trivy-vuln-arm64
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/arm64
         with:
@@ -146,7 +146,7 @@ jobs:
 
       - name: Trivy misconfiguration and secret scan
         id: trivy-config
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/amd64
         with:

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -38,7 +38,7 @@ jobs:
       attestations: write # actions/attest-build-provenance
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -47,14 +47,14 @@ jobs:
         uses: ./.github/composite-actions/resolve-commit-info
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Resolve ECR repository
         id: repo
@@ -62,18 +62,18 @@ jobs:
           echo "repo=${{ steps.ecr-login.outputs.registry }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Download digest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-${{ inputs.app_slug }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Compute tags and labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ steps.repo.outputs.repo }}
           tags: |
@@ -109,7 +109,7 @@ jobs:
 
       # SLSA build provenance attached to the ECR image as an OCI referrer.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ steps.repo.outputs.repo }}
           subject-digest: ${{ steps.inspect.outputs.digest }}
@@ -142,7 +142,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload imagetools inspect JSON
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: imagetools-inspect-${{ inputs.app_slug }}
           path: /tmp/imagetools-inspect.json

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,12 +1,11 @@
 name: ci-cd
 
 on:
-  workflow_dispatch: # This enables the manual execution button
-    inputs:
-      reason:
-        description: 'Reason for running this manually'
-        required: false
-        default: 'Routine check'
+  # No workflow_dispatch: a manual run would treat every package as affected
+  # and re-publish every app, repointing the sha-<sha> and latest tags to
+  # freshly rebuilt digests (provenance/SBOM make rebuilds non-reproducible) —
+  # and it could be dispatched from any branch, publishing sha-tagged images
+  # from unreviewed code. Re-run a failed run via "Re-run all jobs" instead.
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
@@ -113,12 +112,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Log manual run reason
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          REASON: ${{ inputs.reason }}
-        run: echo "**Manual run reason:** ${REASON}" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Verify upstream jobs succeeded
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,6 +113,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Log manual run reason
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REASON: ${{ inputs.reason }}
+        run: echo "**Manual run reason:** ${REASON}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Verify upstream jobs succeeded
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then

--- a/.github/workflows/ecr-cleanup.yml
+++ b/.github/workflows/ecr-cleanup.yml
@@ -49,12 +49,12 @@ jobs:
       # Read deploy targets from the base branch — it always exists, even after
       # the PR branch is deleted on merge.
       - name: Check out base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/monorepo-health.yml
+++ b/.github/workflows/monorepo-health.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare
         uses: ./.github/composite-actions/prepare
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare
         uses: ./.github/composite-actions/prepare

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -55,7 +55,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/heads/main" ]] \
             || { echo "::error::This workflow must be triggered from the main branch (got ${{ github.ref }})"; exit 1; }
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -86,17 +86,17 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Resolve image and extract git SHA
         id: image-info
@@ -193,7 +193,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Two hardening fixes from the CI/CD workflow review, plus a trigger removal that came out of reviewing them:

### Pin all third-party actions to commit SHAs (H2)

Every external `uses:` reference across the workflows and composite actions now points to a full commit SHA with the resolved version as a trailing comment (e.g. `actions/checkout@df4cb1c0… # v6.0.3`). Tags are mutable and can be repointed by a compromised upstream repo; since these workflows assume an OIDC role into AWS, a hijacked action would mean ECR write access. SHAs were resolved from each repo's current tag (peeled commit for annotated tags).

Covers all 39 references across 10 files, including `ecr-cleanup`, `monorepo-health`, and `release-create` — the same actions recur there, so pinning only the ci-cd chain would have left mutable copies of identical references.

### Fix the empty-base case in the `prepare` action (M1)

Triggers without a push payload have no `github.event.before`, so `TURBO_SCM_BASE` was exported as an empty string and `turbo query affected` found nothing. An empty base is now treated like the all-zero first-push case, falling back to the git empty-tree hash so all packages run. With `workflow_dispatch` removed (below) this path is currently unreachable from `ci-cd`, but it is the correct defensive behavior for any future trigger without a push payload (e.g. `schedule`).

### Remove `workflow_dispatch` from `ci-cd`

Reviewing the M1 fix surfaced that a manual run is actively harmful, not just wasteful:

- It treats every package as affected, so it rebuilds and **re-publishes every app** — repointing the supposedly immutable `sha-<sha>` tags (and `latest`, on main) to freshly rebuilt digests, since provenance/SBOM generation makes rebuilds non-reproducible. Those are the refs `release-create`/`release-deploy` pin against.
- It can be dispatched from **any branch**, and the docker chain has no branch guard — only the `latest` tag is gated to `push` + `main`, so sha-tagged images built from unreviewed code would land in the production ECR repos.

Transient failures are better handled by **Re-run all jobs** on the original run (same commit, same event). The trigger, its unused `reason` input, and the reason-logging step are removed; a comment in `ci-cd.yml` documents why, so it doesn't get re-added casually.

## Test plan

- [x] `prettier --check .github` passes (also enforced by the pre-commit hook)
- [x] Verified no unpinned `uses:` references remain (`grep` for tag-style refs returns none)
- [x] Diff is `.github`-only; no workspace package code changed
- [ ] CI green on this PR (exercises the pinned actions on the `pull_request` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)