### PR TITLE
ci(github-actions): add dependabot for actions and zizmor security gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      # `/` covers .github/workflows; composite actions must be listed by the
+      # directory containing their action.yml.
+      - /
+      - /.github/composite-actions/*
+    schedule:
+      interval: weekly
+    # One grouped PR per week instead of one PR (and one full CI run) per
+    # action. Dependabot updates the pinned SHA and the trailing version
+    # comment together.
+    groups:
+      github-actions:
+        patterns: ['*']
+    commit-message:
+      # Match the repo's commitlint convention (subject stays lowercase:
+      # "ci(github-actions): bump ...").
+      prefix: ci(github-actions)

--- a/.github/workflows/_code-quality.yml
+++ b/.github/workflows/_code-quality.yml
@@ -63,3 +63,31 @@ jobs:
 
       - name: Run unit tests
         run: pnpm exec turbo run test --affected -- --reporter=default
+
+  workflow-security:
+    name: Workflow Security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Static analysis of the GitHub Actions workflows themselves: rejects
+      # unpinned third-party actions, template injection into run blocks, and
+      # similar workflow-level vulnerabilities. Gated at high severity;
+      # `annotations: true` (instead of the default SARIF upload) keeps the
+      # job's permissions at contents: read.
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Pinned zizmor version so a new release with new audits can't start
+          # failing unrelated PRs; bump deliberately.
+          version: '1.26.1'
+          min-severity: high
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -96,8 +96,13 @@ jobs:
 
       - name: Resolve ECR repository
         id: repo
+        env:
+          # Via env, not inline expansion: image_name comes from a repo-authored
+          # deploy.json, so it must not reach the shell as code.
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_NAME: ${{ inputs.image_name }}
         run: |
-          echo "repo=${{ steps.ecr-login.outputs.registry }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -73,11 +73,18 @@ jobs:
           pattern: digests-${{ inputs.app_slug }}-*
 
       - name: Resolve per-arch image refs
+        env:
+          # Via env, not inline expansion: app_slug is a directory basename and
+          # image_name comes from a repo-authored deploy.json, so neither must
+          # reach the shell as code.
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_NAME: ${{ inputs.image_name }}
+          APP_SLUG: ${{ inputs.app_slug }}
         run: |
           set -euo pipefail
-          repo="${{ steps.ecr-login.outputs.registry }}/${{ inputs.image_name }}"
-          amd64="$(basename "$(ls /tmp/digests/digests-${{ inputs.app_slug }}-linux-amd64/*)")"
-          arm64="$(basename "$(ls /tmp/digests/digests-${{ inputs.app_slug }}-linux-arm64/*)")"
+          repo="${REGISTRY}/${IMAGE_NAME}"
+          amd64="$(basename "$(ls "/tmp/digests/digests-${APP_SLUG}-linux-amd64"/*)")"
+          arm64="$(basename "$(ls "/tmp/digests/digests-${APP_SLUG}-linux-arm64"/*)")"
           {
             echo "REPO=${repo}"
             echo "AMD64_REF=${repo}@sha256:${amd64}"
@@ -157,6 +164,10 @@ jobs:
         continue-on-error: true
 
       - name: Gate decision
+        env:
+          # Via env, not inline expansion: the threshold is caller-supplied text
+          # and must not reach the shell as code.
+          SEVERITY_THRESHOLD: ${{ inputs.severity_threshold }}
         run: |
           VULN_AMD64="${{ steps.trivy-vuln-amd64.outcome }}"
           VULN_ARM64="${{ steps.trivy-vuln-arm64.outcome }}"
@@ -174,7 +185,7 @@ jobs:
             echo "### Docker security scan"
             echo ""
             echo "**Scanned repo:** \`${REPO}\`"
-            echo "**Severity threshold:** \`${{ inputs.severity_threshold }}\`"
+            echo "**Severity threshold:** \`${SEVERITY_THRESHOLD}\`"
             echo ""
             echo "| Scan | Result |"
             echo "| --- | --- |"

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -58,8 +58,13 @@ jobs:
 
       - name: Resolve ECR repository
         id: repo
+        env:
+          # Via env, not inline expansion: image_name comes from a repo-authored
+          # deploy.json, so it must not reach the shell as code.
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_NAME: ${{ inputs.image_name }}
         run: |
-          echo "repo=${{ steps.ecr-login.outputs.registry }}/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Download digest artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -51,9 +51,13 @@ jobs:
 
     steps:
       - name: Enforce main branch
+        env:
+          # Via env, not inline expansion: a crafted branch name must not reach
+          # the shell as code.
+          REF: ${{ github.ref }}
         run: |
-          [[ "${{ github.ref }}" == "refs/heads/main" ]] \
-            || { echo "::error::This workflow must be triggered from the main branch (got ${{ github.ref }})"; exit 1; }
+          [[ "$REF" == "refs/heads/main" ]] \
+            || { echo "::error::This workflow must be triggered from the main branch (got $REF)"; exit 1; }
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -199,6 +203,9 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          # Scope the token to the one permission `gh release create` needs,
+          # instead of inheriting the app installation's full permission set.
+          permission-contents: write
 
       - name: Create release (triggers release-deploy.yml)
         env:


### PR DESCRIPTION
## Summary

Follow-up to #546 (stacked on that branch — merge #546 first; GitHub will retarget this PR to `main` automatically). Keeps the new commit-SHA pins from going stale and adds CI enforcement so the pinning discipline is self-checking.

### Dependabot (`.github/dependabot.yml`)

- `github-actions` ecosystem, weekly, **grouped into a single PR** so 14 actions don't trigger 14 full CI runs (docker builds included).
- `directories` covers both `.github/workflows/` and the composite actions (`prepare`, `resolve-commit-info`), which the default `/` alone does not.
- Dependabot understands the `@<sha> # vX.Y.Z` format from #546 and bumps SHA + comment together.
- `commit-message.prefix: ci(github-actions)` keeps commitlint green.

### zizmor gate (`workflow-security` job in `_code-quality.yml`)

- Runs [zizmor](https://docs.zizmor.sh) over `.github/` gated at `min-severity: high`. Verified empirically that a tag-pinned third-party action is a **high** finding under the default blanket policy, so this rejects any future unpinned `uses:` — the enforcement gap Dependabot leaves open.
- `advanced-security: false` + `annotations: true` so the job needs only `contents: read` (the reusable workflow is called with exactly that); findings surface as PR annotations instead of the Security tab.
- zizmor version pinned (`1.26.1`) so a new release with new audits can't start failing unrelated PRs; the action itself is SHA-pinned like everything else.

### High-severity findings fixed (so the gate lands green)

zizmor found 9 high-severity issues, all remediated in the first commit:

- **Template injection (7×):** `inputs.image_name` / `inputs.app_slug` / `severity_threshold` / `github.ref` were expanded inline in `run:` blocks in `_docker-build-stage`, `_docker-security-scan`, `_ecr-publish`, and `release-create`. These values originate from repo-authored `deploy.json` files, directory names, and branch names — now routed through `env:` (finding M2 from the workflow review).
- **GitHub App token over-scoping (1 finding):** `actions/create-github-app-token` in `release-create.yml` now sets `permission-contents: write` — the only permission `gh release create` needs — instead of inheriting the installation's full permission set (input name verified against the action's `action.yml` at the pinned SHA).

Remaining medium/informational findings (13 medium, mostly `excessive-permissions` on jobs without explicit blocks and `artipacked` persist-credentials) are intentionally not gated yet; tighten with a `zizmor.yml` config later if desired.

## Test plan

- [x] `zizmor --min-severity high .github` passes locally, both offline and with online audits enabled (exit 0, no findings)
- [x] Verified tag-pinned actions produce high-severity findings (gate actually enforces pinning)
- [x] `permission-contents` input verified against `create-github-app-token` v3.2.0 `action.yml`
- [x] Prettier passes via pre-commit hook
- [ ] CI green on this PR, including the new `Workflow Security` job
- [ ] After merge: confirm Dependabot's first scheduled run opens a grouped PR (Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)