### PR TITLE
ci(github-actions): add actionlint to the workflow security job

### DIFF
--- a/.github/workflows/_code-quality.yml
+++ b/.github/workflows/_code-quality.yml
@@ -91,3 +91,13 @@ jobs:
           min-severity: high
           advanced-security: false
           annotations: true
+
+      # Complements zizmor: actionlint checks workflow correctness (invalid
+      # needs/outputs references, expression type errors, bad runner labels)
+      # and runs shellcheck over run blocks. Security auditing stays with
+      # zizmor above.
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          # Pinned actionlint version for the same reason as zizmor above.
+          version: 1.7.12

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -93,10 +93,19 @@ jobs:
 
       - name: Create and push multi-arch manifest
         working-directory: /tmp/digests
+        env:
+          REPO: ${{ steps.repo.outputs.repo }}
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ steps.repo.outputs.repo }}@sha256:%s ' *)
+          set -euo pipefail
+          args=()
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          # Each file in /tmp/digests is named after a per-arch digest hex.
+          for digest in *; do
+            args+=("${REPO}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${args[@]}"
 
       - name: Inspect manifest and capture digest
         id: inspect

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -190,7 +190,7 @@ jobs:
           # appear. Acceptable for a human-readable changelog.
           {
             echo "notes<<$DELIM"
-            git log ${RANGE:-$GIT_SHA} --pretty='- %s (%h)' -- "apps/$APP" "packages/" \
+            git log "${RANGE:-$GIT_SHA}" --pretty='- %s (%h)' -- "apps/$APP" "packages/" \
               || echo "- Initial release"
             echo "$DELIM"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Follow-up to #548: adds **actionlint** alongside zizmor in the `workflow-security` job. The two cover disjoint failure classes — zizmor audits security (unpinned actions, template injection), actionlint checks correctness: invalid `needs:`/outputs references, expression type errors, bad runner labels, and shellcheck/pyflakes over `run:` blocks. Those bugs currently ship silently and only surface at run time.

- Runs via `raven-actions/actionlint`, SHA-pinned (`v2.2.0`), with the actionlint version pinned to `1.7.12` for deterministic CI (same rationale as the zizmor version pin). Input names verified against the action's `action.yml`.
- No extra permissions needed; findings surface as PR annotations via the built-in problem matcher.

### Shellcheck findings fixed (first commit)

Running actionlint locally **with shellcheck enabled** (runners have it preinstalled; a bare local run silently skips it) surfaced three quoting issues, fixed so the gate lands green:

- `_ecr-publish.yml` — the `imagetools create` invocation built its argument list via unquoted command-substitution word splitting (SC2046 ×2). Rewritten with a bash array; same tags and digest refs, no splitting hazards.
- `release-create.yml` — unquoted `${RANGE:-$GIT_SHA}` in the changelog `git log` (SC2086). Always a single word, now quoted.

## Test plan

- [x] `actionlint -shellcheck …` (v1.7.12 + shellcheck 0.11.0) passes locally on the final state
- [x] `zizmor --min-severity high .github` still passes
- [x] Prettier passes via pre-commit hook
- [ ] CI green, including the extended `Workflow Security` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)