### PR TITLE
ci(github-actions): skip docker pipeline on fork prs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,9 +47,17 @@ jobs:
   # Build both arches on native runners and push to ECR by digest (untagged).
   # The build stage verifies the target ECR repository already exists (provisioned
   # out-of-band via IaC) and hard-stops if it doesn't.
+  # Skipped for PRs from forks: fork runs get a read-only token (id-token: write
+  # is refused) and no repository secrets/vars, so the AWS OIDC steps would
+  # hard-fail and block the merge via ci-cd-passed. Skipping here cascades to
+  # docker-scan and docker-publish; ci-cd-passed treats skips as passing. The
+  # full build/scan/publish still runs on the push to main after merge.
   docker-build:
     needs: [deploy-matrix]
-    if: needs.deploy-matrix.outputs.has_apps == 'true'
+    if: >-
+      needs.deploy-matrix.outputs.has_apps == 'true' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     name: docker-build (${{ matrix.target.app_name }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Implements **M3** from the CI/CD review: PRs opened from forks currently hard-fail the pipeline and block merges.

### Problem

On a `pull_request` run from a fork, GitHub downgrades the workflow token to read-only — the `id-token: write` permission is refused — and repository secrets/variables (`AWS_GHA_ROLE_ARN`, `AWS_REGION`) are not exposed to the run. If the fork's changes touch a deployable app, `docker-build` reaches `configure-aws-credentials`, fails, and `ci-cd-passed` reports failure — so a legitimate outside contribution can never merge.

### Fix

Gate `docker-build` on the PR head repo being this repository:

```yaml
if: >-
  needs.deploy-matrix.outputs.has_apps == 'true' &&
  (github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository)
```

- `docker-scan` and `docker-publish` need no changes: their `if` conditions have no status-check function, so the implicit `success()` applies and they cascade-skip when `docker-build` is skipped.
- `ci-cd-passed` already treats skipped jobs as passing, so fork PRs go green on code quality + affected-package computation alone.
- `head.repo.full_name` comparison (rather than `head.repo.fork`) also safely skips when the head repo is null (deleted fork).

### Trade-off

Fork PRs merge without a PR-time image build/Trivy scan. The push to `main` after merge runs the full build → scan → publish pipeline, and the Trivy gate still blocks tagging/publishing a vulnerable image — detection moves post-merge for fork contributions, which is the standard posture for OIDC-backed pipelines.

### Verification

- `zizmor --min-severity high`: no findings
- `actionlint` (with shellcheck): no findings
- prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)