### PR TITLE
ci(github-actions): isolate pr docker build cache from main

### DIFF
--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -126,6 +126,36 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
+      # PR builds must not write the cache that main builds consume: an
+      # unreviewed PR could otherwise seed poisoned layers that the next main
+      # build — the one that publishes `latest` — would trust. PRs read their
+      # own cache-pr-<n>-<platform> tag first (warm across pushes to the same
+      # PR), fall back to main's cache read-only, and write only their own
+      # pr-scoped tag, which ecr-cleanup.yml deletes when the PR closes. Main
+      # builds keep the unscoped cache-<platform> tag, so existing cache stays
+      # valid.
+      - name: Resolve build cache refs
+        id: cache
+        env:
+          REPO: ${{ steps.repo.outputs.repo }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          main_ref="${REPO}:cache-${PLATFORM_PAIR}"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            pr_ref="${REPO}:cache-pr-${PR_NUMBER}-${PLATFORM_PAIR}"
+            {
+              echo "cache_from<<EOF"
+              echo "type=registry,ref=${pr_ref}"
+              echo "type=registry,ref=${main_ref}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "cache_to=type=registry,ref=${pr_ref},mode=max,image-manifest=true,oci-mediatypes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_from=type=registry,ref=${main_ref}" >> "$GITHUB_OUTPUT"
+            echo "cache_to=type=registry,ref=${main_ref},mode=max,image-manifest=true,oci-mediatypes=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Push by digest only — no tags here. The 'publish' job stitches the
       # per-platform digests into a single tagged multi-arch manifest.
       - name: Build and push by digest
@@ -142,11 +172,11 @@ jobs:
             VERSION=sha-${{ steps.commit-info.outputs.full_sha }}
           outputs: type=image,name=${{ steps.repo.outputs.repo }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
-          # Registry cache stored in the app's own ECR repo under a cache-<platform>
-          # tag. Unlike type=gha, ECR cache is not branch-scoped so PR and main
-          # builds share the same warm layers.
-          cache-from: type=registry,ref=${{ steps.repo.outputs.repo }}:cache-${{ env.PLATFORM_PAIR }}
-          cache-to: type=registry,ref=${{ steps.repo.outputs.repo }}:cache-${{ env.PLATFORM_PAIR }},mode=max,image-manifest=true,oci-mediatypes=true
+          # Registry cache stored in the app's own ECR repo. Refs are computed
+          # above: PR builds read pr-scoped + main cache but write only their
+          # own pr-scoped tag; main builds read/write the unscoped tag.
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}
           provenance: mode=max
           sbom: true
 

--- a/.github/workflows/ecr-cleanup.yml
+++ b/.github/workflows/ecr-cleanup.yml
@@ -7,6 +7,7 @@
 # marker ci-cd uses), so this scales automatically as apps are added. For each
 # repo we delete:
 #   - the mutable pr-<n> tag
+#   - the PR's per-arch build cache tags (cache-pr-<n>-<platform>)
 #   - the immutable sha-<full> tag for every commit that was in the PR
 #
 # Deleting the tagged multi-arch manifests leaves their per-arch child layers
@@ -66,9 +67,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # pr-<n> is always a candidate; then one sha-<full> per PR commit.
+          # pr-<n> is always a candidate, as are the PR's per-arch build cache
+          # tags (the platform list mirrors the build matrix in
+          # _docker-build-stage.yml); then one sha-<full> per PR commit.
           # The commits API returns the full 40-char SHA, matching the publish tag.
           image_ids=( "imageTag=pr-${PR_NUMBER}" )
+          for platform_pair in linux-amd64 linux-arm64; do
+            image_ids+=( "imageTag=cache-pr-${PR_NUMBER}-${platform_pair}" )
+          done
           while read -r sha; do
             [ -n "$sha" ] && image_ids+=( "imageTag=sha-${sha}" )
           done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[].sha')


### PR DESCRIPTION
## Summary

Implements **M4** from the CI/CD review: PR builds write to the same ECR registry build cache that main builds consume.

### Problem

`_docker-build-stage.yml` used a single `cache-<platform>` tag for both `cache-from` and `cache-to` on every run, regardless of trigger:

- **Cache poisoning:** a PR build runs unreviewed code (Dockerfile changes, build scripts) with `mode=max` cache export. Layers it writes are trusted verbatim by the next main build — the one that publishes `latest` and the `sha-<sha>` tags — so a malicious or simply broken PR could seed layer content into a production image.
- **Cache churn:** concurrent/alternating PR and main builds overwrite each other's cache tag, evicting main's warm layers and slowing every build.

### Fix

A new `Resolve build cache refs` step computes the refs per trigger:

| Trigger | cache-from (read) | cache-to (write) |
| --- | --- | --- |
| `pull_request` | `cache-pr-<n>-<platform>`, then `cache-<platform>` fallback | `cache-pr-<n>-<platform>` only |
| `push` (main) | `cache-<platform>` | `cache-<platform>` |

- Main's cache can now only be written by main builds; PRs consume it read-only (reading is safe — poisoning requires the write path).
- PR builds stay warm across pushes to the same PR via their own scoped tag, and a fresh PR falls back to main's cache, so build times are unchanged.
- Main keeps the existing unscoped tag name, so the currently warm cache survives this change (no one-time cold rebuild).
- `ecr-cleanup.yml` now also deletes the PR's `cache-pr-<n>-<platform>` tags when the PR closes (merged or not), so scoped caches don't accumulate.

### Verification

- `zizmor --min-severity high`: no findings
- `actionlint` (with shellcheck): no findings
- prettier: clean
- Simulated the cache-ref script for both `pull_request` and `push` events — outputs produce exactly the refs in the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)