### PR TITLE
ci(github-actions): build pr images from the pr head commit

### DIFF
--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -62,9 +62,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Need the PR head commit (a parent of the merge ref) available
-          # locally so `git show` can read its committer date for BUILD_DATE.
-          fetch-depth: 2
+          # Build from the PR head commit, not the ephemeral merge ref that
+          # pull_request events check out by default: the image is tagged
+          # sha-<head sha> and labeled with that revision, so the bytes must
+          # come from exactly that commit. Building the merge ref would claim
+          # a commit the image wasn't built from, and re-running the job after
+          # main moves would repoint the same sha- tag to different bytes.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Resolve commit SHA and build date
         id: commit-info

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 2
+          # Same ref the build stage checked out (PR head, not the ephemeral
+          # merge ref) so the recomputed tags/labels describe the commit the
+          # image bytes were actually built from.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Resolve commit SHA and build date
         id: commit-info


### PR DESCRIPTION
## Summary

The `sha-<sha>` image tag doesn't match the commit the image was built from on PR runs.

### Problem

On `pull_request` events, `actions/checkout` defaults to `github.sha` — the **ephemeral merge commit** (PR head merged into main at run time) — while `resolve-commit-info` deliberately resolves the **PR head SHA** for the `sha-<sha>` tag and the `org.opencontainers.image.revision` label. Consequences:

- The tag and revision label claim bytes built from a commit whose tree the image was **not** built from; the merge tree it was built from is unfetchable once the run ends.
- Re-running the same PR job after main moves rebuilds the **same** `sha-<head>` tag from a **different** merge tree — the supposedly commit-pinned tag silently repoints to different bytes.
- Today `release-create` rejects PR-built images only as a side effect of the squash-merge convention (head SHAs never land on main). Under merge-commit merges, its ancestry check would pass for a mislabeled image.

### Fix

Check out the PR head commit explicitly in `_docker-build-stage.yml` and `_ecr-publish.yml`:

```yaml
ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

Now `sha-X` unconditionally means "built from commit X", re-runs are deterministic per SHA, and the revision label is truthful. Push-to-main runs are unchanged (`github.sha` is the real commit there). `fetch-depth: 2` is dropped — it existed only so `git show` could reach the head commit as a parent of the merge ref; with the head checked out directly, the default depth suffices.

### Trade-off

PR **docker images** are now built from the PR head tree rather than the merged tree (code-quality jobs still test the merge ref). The merged tree's image is built, scanned, and published by the push-to-main run after merge — which is the only releasable image anyway.

### Verification

- `zizmor --min-severity high`: no findings (checking out the PR head is safe under `pull_request` — the token is unprivileged, unlike `pull_request_target`)
- `actionlint` (with shellcheck): no findings
- prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)