### PR TITLE
ci(github-actions): run every main commit instead of superseding queued runs

### DIFF
--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -79,6 +79,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # Main runs are concurrency-grouped per commit (see ci-cd.yml), so two can
+      # publish in parallel. Only the run whose commit is still the head of
+      # main applies `latest` — otherwise an older commit's slower run
+      # finishing last would repoint `latest` backwards. When this run skips
+      # it, the newer commit's own run applies `latest` instead.
+      - name: Check whether this commit is still the head of main
+        id: head-check
+        if: github.event_name == 'push'
+        env:
+          SHA: ${{ steps.commit-info.outputs.full_sha }}
+        run: |
+          set -euo pipefail
+          head="$(git ls-remote origin refs/heads/main | cut -f1)"
+          is_head=false
+          [[ "$head" == "$SHA" ]] && is_head=true
+          echo "is_head=${is_head}" >> "$GITHUB_OUTPUT"
+          echo "Commit ${SHA} vs main head ${head} — is_head=${is_head}"
+
       - name: Compute tags and labels
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -87,7 +105,7 @@ jobs:
           tags: |
             type=raw,value=sha-${{ steps.commit-info.outputs.full_sha }}
             type=ref,event=pr,prefix=pr-
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.head-check.outputs.is_head == 'true' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.commit-info.outputs.full_sha }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,8 +13,14 @@ on:
     branches: [main]
     tags-ignore: ['**']
 
+# PRs: one run per ref, the newest push wins. Pushes to main: one group per commit —
+# a shared main group would let GitHub's single-slot pending queue supersede a
+# queued run when merges land quickly, leaving that commit with no sha-<sha>
+# image (unreleasable) and a spurious red X. Parallel main runs racing to tag
+# `latest` are handled in _ecr-publish.yml, which only applies `latest` when
+# its commit is still the head of main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default-deny at the workflow root; jobs that need more elevate per job.


### PR DESCRIPTION
## Summary

Implements **M6** from the CI/CD review: the shared concurrency group on main can silently skip building intermediate commits.

### Problem

`concurrency.group` was ref-scoped for all triggers. GitHub keeps at most **one pending run per group**: while commit A's run executes and B's waits, merging C cancels B's run outright ("superseded by a higher priority request"). Commit B then:

- never gets a `sha-<B>` image in ECR — `release-create` can never release it
- shows a permanent red ❌ on main (the cancelled `ci-cd-passed`)

### Fix

**`ci-cd.yml`** — scope push runs per commit; PRs keep ref-scoped newest-wins cancellation:

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
```

Every main commit now gets its own run, so `sha-*` image coverage has no gaps.

**`_ecr-publish.yml`** — per-commit groups mean main runs can publish in parallel, which opens one race: an older commit's slower run finishing last could repoint `latest` backwards. A new `head-check` step (`git ls-remote origin refs/heads/main`) gates the `latest` tag so only the run whose commit is still the head of main applies it. When a run skips `latest`, the newer commit's own run applies it — `latest` converges to the newest commit either way. `sha-<sha>` and `pr-<n>` tagging is unchanged.

### Notes

- The check-then-tag window is a few seconds; a wrong ordering within it requires two merges landing closer together than that and the older run finishing inside the window — strictly better than today, where the same scenario silently drops a commit's image entirely.
- Parallel main runs racing on the shared `cache-<platform>` write are benign (last writer wins; readers fall back to a full build on miss).

### Verification

- `zizmor --min-severity high`: no findings
- `actionlint` (with shellcheck): no findings
- prettier: clean
- Simulated the head-check script for match and mismatch — `is_head` computes correctly and the mismatch path doesn't trip `set -e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)