### PR TITLE
ci(release): enforce release-create as the only release path

### DIFF
--- a/.github/workflows/release-block-manual.yml
+++ b/.github/workflows/release-block-manual.yml
@@ -1,0 +1,77 @@
+# Defense-in-depth ONLY — not the actual guarantee.
+#
+# The real control that makes release-create.yml the sole path to a release is a
+# GitHub *tag ruleset*: restrict creation of `*@v*` tags to the RELEASE_BOT_APP
+# GitHub App (add the App to the ruleset bypass list, block everyone else).
+# Because creating a release requires creating its tag, that blocks manual
+# releases *before* they exist.
+#
+# This workflow is a reactive backstop for anything that slips past the ruleset
+# (e.g. an admin bypass): it fires after the release is already published, so it
+# can only delete-and-alert, never prevent. release-deploy.yml independently
+# verifies provenance before deploying, so a manual release cannot deploy even in
+# the window before this cleanup runs.
+
+name: release-block-manual
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # delete the offending release and its tag
+
+jobs:
+  block-manual:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Derive the release bot's identity from the App credentials themselves —
+      # the same client-id/private-key release-create.yml uses — so there's a
+      # single source of truth and nothing to keep in sync. The bot login is
+      # always "<app-slug>[bot]". Token scoped to nothing (permission-contents:
+      # none): we only read the app-slug output, we don't act with it.
+      - name: Resolve release bot identity
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: none
+
+      - name: Delete releases not created by the release bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Passed via env (never inlined) so crafted values can't reach the shell as code.
+          EXPECTED_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          # author.login is the account that created the release (the App bot for a legit release).
+          AUTHOR: ${{ github.event.release.author.login }}
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+
+          # Fail safe: if we couldn't resolve the app slug, delete nothing rather
+          # than risk removing a legitimate release. (The token step failing would
+          # already have aborted the job before here.)
+          if [[ -z "$APP_SLUG" ]]; then
+            echo "::warning::Could not resolve the release bot's app slug — deleting nothing."
+            exit 0
+          fi
+
+          if [[ "$AUTHOR" == "$EXPECTED_LOGIN" ]]; then
+            echo "Release $TAG was created by the release bot (@$AUTHOR) — allowed."
+            exit 0
+          fi
+
+          echo "::error::Manual release detected: $TAG ($URL) was created by @$AUTHOR, not the release bot (@$EXPECTED_LOGIN). Deleting it — use the release-create workflow instead."
+          # --cleanup-tag removes the git tag too, so a re-run of release-create
+          # for the same version isn't blocked by a leftover tag. (If a tag
+          # ruleset also restricts tag *deletion*, add GITHUB_TOKEN's actor to its
+          # bypass list, or the tag will remain.)
+          gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes
+          exit 1

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,6 +1,14 @@
 # Fires when release-create.yml creates a GitHub release (gh release create).
-# Placeholder: only echoes the release payload for now — deployment logic
-# gets wired in on top of this once the trigger is confirmed working.
+#
+# Before doing anything, verify-provenance re-checks that the release could only
+# have come from release-create.yml — the tag matches the <app>@v<semver> scheme
+# and points at a commit on main. This makes the deploy independent of
+# release-block-manual.yml: a manually-created release (which could tag an
+# arbitrary commit) cannot deploy even in the window before that cleanup workflow
+# deletes it.
+#
+# The deploy job is a placeholder: only echoes the release payload for now —
+# deployment logic gets wired in on top of this once the trigger is confirmed working.
 
 name: release-deploy
 
@@ -8,8 +16,42 @@ on:
   release:
     types: [released, prereleased]
 
+permissions:
+  contents: read
+
 jobs:
-  echo:
+  verify-provenance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history + tags, so we can resolve the tag and test ancestry
+
+      - name: Verify release provenance
+        env:
+          # Passed via env (never inlined) so a crafted tag can't reach the shell as code.
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # 1. Tag must match the scheme release-create.yml produces: <app>@v<semver>.
+          [[ "$TAG" =~ ^[a-z0-9][a-z0-9-]*@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
+            || { echo "::error::Refusing to deploy: tag '$TAG' is not a valid <app>@v<semver> release tag"; exit 1; }
+
+          # 2. The tagged commit must be an ancestor of main — a manual release
+          #    could tag any arbitrary commit. This is the load-bearing check:
+          #    release-create.yml only ever tags commits already on main. Fetch
+          #    main explicitly rather than trusting remote-tracking refs to exist.
+          git fetch --no-tags origin main
+          SHA=$(git rev-list -n1 "$TAG")
+          git merge-base --is-ancestor "$SHA" FETCH_HEAD \
+            || { echo "::error::Refusing to deploy: $TAG points at $SHA, which is not an ancestor of main"; exit 1; }
+
+          echo "Provenance OK: $TAG → $SHA is on main"
+
+  deploy:
+    needs: verify-provenance
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Problem

Manual GitHub releases (via the UI or API) could trigger `release-deploy.yml`, and the manual-release guard (`release-block-manual.yml`) was broken:

- It allowlisted `github-actions[bot]`, but `release-create.yml` creates releases with the **RELEASE_BOT_APP** App token — so a legitimate release's author is `<app-slug>[bot]`. The guard would have **deleted every real release**.
- The `run:` block was malformed: an uncommented prose line, `env:` nested inside `run:` (so `GH_TOKEN` was never set), and no `permissions:`.

Reactive deletion also can't *guarantee* anything: `release: published` fires after the release exists, concurrently with the deploy.

## Changes

**`release-deploy.yml` — provenance gate**
- New `verify-provenance` job the `deploy` job `needs:`. Rejects any release unless the tag matches `<app>@v<semver>` **and** the tagged commit is an ancestor of `main`. Since `release-create.yml` only tags commits on `main`, a manual release (which could tag any commit) cannot deploy — independent of the cleanup workflow winning any race.

**`release-block-manual.yml` — fail-safe backstop**
- Rewritten. Derives the release bot's identity from the App credentials via `create-github-app-token` (`app-slug` output, token scoped to `permission-contents: none`), so there's **no `RELEASE_BOT_LOGIN` var to configure or drift**.
- Deletes + fails on any release not authored by the bot, using `GITHUB_TOKEN` with `contents: write` and `--cleanup-tag`.
- Fail-safe: if the identity can't be resolved, it deletes nothing.

## The actual guarantee (follow-up, not in this PR)

A **tag ruleset** restricting `*@v*` tag creation to the RELEASE_BOT_APP App is the only true prevention; these workflows are defense-in-depth around it. A `gh api` script to create it will be provided separately.

> Note: if that ruleset also restricts tag *deletion*, add `github-actions` to its bypass list or `--cleanup-tag` won't remove the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)