### PR TITLE
fix(release): scope release bot token to metadata:read

### DIFF
--- a/.github/workflows/release-block-manual.yml
+++ b/.github/workflows/release-block-manual.yml
@@ -29,8 +29,12 @@ jobs:
       # Derive the release bot's identity from the App credentials themselves —
       # the same client-id/private-key release-create.yml uses — so there's a
       # single source of truth and nothing to keep in sync. The bot login is
-      # always "<app-slug>[bot]". Token scoped to nothing (permission-contents:
-      # none): we only read the app-slug output, we don't act with it.
+      # always "<app-slug>[bot]". We only read the app-slug output and never act
+      # with the token. There is no zero-permission token (metadata:read is
+      # always implied), and omitting all permission-* inputs makes the action
+      # inherit ALL the installation's permissions — so pin it to the minimum:
+      # metadata:read. ("none"/empty are not valid; empty is skipped, which
+      # would fall back to inherit-all.)
       - name: Resolve release bot identity
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -39,7 +43,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          permission-contents: none
+          permission-metadata: read
 
       - name: Delete releases not created by the release bot
         env:


### PR DESCRIPTION
## Problem

`release-block-manual.yml` failed on its first real run ([run 28664529102](https://github.com/mpellegrini/fullstack-typescript-monorepo-starter/actions/runs/28664529102)) at the *Resolve release bot identity* step:

> There is at least one permission action that is not supported. It should be one of: "read", "write" or "admin".

The step passed `permission-contents: none`, but `create-github-app-token` only accepts `read`/`write`/`admin`.

## Why not `{}` / empty / omit

Per the action's parser (`lib/get-permissions-from-inputs.js`), empty values are skipped, and if no permission input survives it returns `undefined` — which makes the token **inherit all** installation permissions (the broadest, not the narrowest). There is also no zero-permission token: `metadata: read` is always implied.

## Fix

The token is only used to read the `app-slug` output and never acts, so pin it to the minimum meaningful scope: **`permission-metadata: read`**.

## Note on behavior

This only fixes the token step. When a genuine **manual** release triggers this workflow, the guard will (by design) delete that release and `exit 1` — so a red run on a manual release is the intended fail-loud outcome, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)