### PR TITLE
fix(release): require bot authorship before deploying a release

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,11 +1,13 @@
 # Fires when release-create.yml creates a GitHub release (gh release create).
 #
 # Before doing anything, verify-provenance re-checks that the release could only
-# have come from release-create.yml — the tag matches the <app>@v<semver> scheme
-# and points at a commit on main. This makes the deploy independent of
-# release-block-manual.yml: a manually-created release (which could tag an
-# arbitrary commit) cannot deploy even in the window before that cleanup workflow
-# deletes it.
+# have come from release-create.yml. The load-bearing check is authorship: the
+# release must have been created by the RELEASE_BOT_APP GitHub App — a human
+# cannot author as the App. Tag format and commit-on-main are additional sanity
+# checks (a well-formed manual release on a main commit passes those, so they are
+# NOT sufficient on their own). This makes the deploy independent of
+# release-block-manual.yml: a manually-created release cannot deploy even in the
+# window before that cleanup workflow deletes it.
 #
 # The deploy job is a placeholder: only echoes the release payload for now —
 # deployment logic gets wired in on top of this once the trigger is confirmed working.
@@ -24,31 +26,53 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Derive the release bot's login from the App credentials (same single
+      # source of truth as release-block-manual.yml); "<app-slug>[bot]". Token is
+      # only read for its app-slug output, so scope it to the minimum: metadata:read.
+      - name: Resolve release bot identity
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-metadata: read
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # full history + tags, so we can resolve the tag and test ancestry
 
       - name: Verify release provenance
         env:
-          # Passed via env (never inlined) so a crafted tag can't reach the shell as code.
+          # Passed via env (never inlined) so crafted values can't reach the shell as code.
           TAG: ${{ github.event.release.tag_name }}
+          AUTHOR: ${{ github.event.release.author.login }}
+          EXPECTED_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
 
-          # 1. Tag must match the scheme release-create.yml produces: <app>@v<semver>.
+          # 1. LOAD-BEARING: the release must have been authored by the release bot.
+          #    This is the only signal a human cannot forge — a well-formed manual
+          #    release on a main commit passes checks 2 and 3 below.
+          [[ -n "$APP_SLUG" ]] \
+            || { echo "::error::Could not resolve the release bot identity — refusing to deploy"; exit 1; }
+          [[ "$AUTHOR" == "$EXPECTED_LOGIN" ]] \
+            || { echo "::error::Refusing to deploy: $TAG was created by @$AUTHOR, not the release bot (@$EXPECTED_LOGIN)"; exit 1; }
+
+          # 2. Sanity: tag matches the scheme release-create.yml produces.
           [[ "$TAG" =~ ^[a-z0-9][a-z0-9-]*@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
             || { echo "::error::Refusing to deploy: tag '$TAG' is not a valid <app>@v<semver> release tag"; exit 1; }
 
-          # 2. The tagged commit must be an ancestor of main — a manual release
-          #    could tag any arbitrary commit. This is the load-bearing check:
-          #    release-create.yml only ever tags commits already on main. Fetch
-          #    main explicitly rather than trusting remote-tracking refs to exist.
+          # 3. Sanity: the tagged commit is an ancestor of main. Fetch main
+          #    explicitly rather than trusting remote-tracking refs to exist.
           git fetch --no-tags origin main
           SHA=$(git rev-list -n1 "$TAG")
           git merge-base --is-ancestor "$SHA" FETCH_HEAD \
             || { echo "::error::Refusing to deploy: $TAG points at $SHA, which is not an ancestor of main"; exit 1; }
 
-          echo "Provenance OK: $TAG → $SHA is on main"
+          echo "Provenance OK: $TAG → $SHA is on main, authored by @$AUTHOR"
 
   deploy:
     needs: verify-provenance


### PR DESCRIPTION
## Problem

A manual test release triggered `release-deploy` and it **deployed** ([run](https://github.com/mpellegrini/fullstack-typescript-monorepo-starter/actions/runs/28665710881/job/85016801477)). The release was created by a User (`mpellegrini`) with tag `effect-api-foo@v1.0.0` targeting `main`.

`verify-provenance` only checked:
1. tag format `<app>@v<semver>` — passed (well-formed)
2. tagged commit is an ancestor of `main` — passed (targeted `main`)

Neither check looks at **who** created the release, so a human can hand-craft a valid-looking release tag on any main commit and it deploys. My earlier claim that the on-main check "already blocks manual releases" was wrong.

## Fix

Add the load-bearing check to `verify-provenance`: the release must be **authored by the RELEASE_BOT_APP** GitHub App — something a human cannot forge. Identity is derived from the App credentials via `create-github-app-token` (`app-slug` → `<app-slug>[bot]`), the same single source of truth used by `release-block-manual.yml`. Tag format and commit-on-main remain as sanity checks.

## Result

- Legit release-create.yml release (authored by the bot) → deploys.
- Manual release (authored by a human), even well-formed and on main → `verify-provenance` fails, no deploy. Independent of whether `release-block-manual.yml` wins the delete race.

Note: the tag ruleset (restrict `*@v*` creation to the App) remains the real prevention; this is defense-in-depth so a manual release can't deploy in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)