### PR TITLE
fix(release): grant workflows:write to the release token

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -203,9 +203,14 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          # Scope the token to the one permission `gh release create` needs,
-          # instead of inheriting the app installation's full permission set.
+          # contents: write to create the release + tag. workflows: write is
+          # required because the tag is pinned to the image's commit (--target
+          # $GIT_SHA), which can be behind a later commit that changed
+          # .github/workflows/**; GitHub blocks an App token from creating a ref
+          # pointing at a differing workflow tree without the workflows scope,
+          # failing with "Resource not accessible by integration".
           permission-contents: write
+          permission-workflows: write
 
       - name: Create release (triggers release-deploy.yml)
         env:


### PR DESCRIPTION
## Symptom

`release-create` failed at **Create release** with:

```
HTTP 403: Resource not accessible by integration (.../releases)
```

…even though the App token minted fine and had `contents: write`.

## Root cause (bisected in CI + reproduced via the App API)

`release-create` intentionally pins the tag to the **image's commit** (`gh release create --target $GIT_SHA`). When that commit is *behind* a later commit that modified `.github/workflows/**`, GitHub refuses to let a **GitHub App token** create a ref/tag pointing at the differing workflow tree **unless the token has the `workflows` permission** — surfacing as `Resource not accessible by integration`.

Evidence (same App, same repo, same target commit `72c2c79`, which predates the workflow change in #562):

| Token permissions | `gh release create --target <that commit>` |
|---|---|
| `contents: write` | **403** |
| `contents: write` + `workflows: write` | **201 ✅** |

Releases whose target is the branch tip (matching workflow tree) always worked — which is why this only started failing after #560–#562 touched `.github/workflows/`, leaving releasable image commits behind a workflow change.

## Fix

Add `permission-workflows: write` to the `create-github-app-token` step (the App already grants `workflows: write`). One line; no behavior change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)