### PR TITLE
fix(ci): split aws oidc into pr and main roles

### DIFF
--- a/.github/docs/aws-oidc-roles.md
+++ b/.github/docs/aws-oidc-roles.md
@@ -1,0 +1,137 @@
+# AWS OIDC roles for GitHub Actions
+
+CI authenticates to AWS exclusively via GitHub's OIDC provider — no long-lived
+keys. Two IAM roles exist, and the split is a security boundary, not an
+organizational nicety.
+
+## Why two roles
+
+`pull_request` workflows execute the **PR branch's copy** of the workflow
+files. Any YAML-side guard (the scan gate, the digest-only push discipline, the
+`latest` head-of-main check) can be edited away by the PR itself. The only
+control the PR cannot forge is the **OIDC token's `sub` claim**, which GitHub
+sets from the trigger:
+
+| Trigger | `sub` claim |
+| --- | --- |
+| `pull_request` | `repo:<owner>/<repo>:pull_request` |
+| `push` to main, `workflow_dispatch` on main, `pull_request_target` | `repo:<owner>/<repo>:ref:refs/heads/main` |
+
+So the IAM **trust policies** are the real enforcement point: a PR-modified
+workflow physically cannot assume the trusted role, no matter what its YAML
+says.
+
+## Role: `gha-ci-pr` → repo variable `AWS_GHA_PR_ROLE_ARN`
+
+Assumed by `_docker-build-stage.yml`, `_docker-security-scan.yml`, and
+`_ecr-publish.yml` on `pull_request` events. Push/pull only — **no delete**.
+
+Trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:<OWNER>/<REPO>:pull_request"
+        }
+      }
+    }
+  ]
+}
+```
+
+Permission policy (resource-scoped to the app image repos — the `imageName`
+values in `apps/*/deploy.json`, all under the `monorepo/` prefix):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPushPull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:DescribeRepositories",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "arn:aws:ecr:<REGION>:<ACCOUNT_ID>:repository/monorepo/*"
+    }
+  ]
+}
+```
+
+## Role: `gha-ci-main` → repo variable `AWS_GHA_ROLE_ARN`
+
+Assumed on `push` to main (build/scan/publish), `workflow_dispatch` from main
+(`release-create.yml`), and `pull_request_target` (`ecr-cleanup.yml` — which
+runs the base branch's reviewed workflow code, never the PR's).
+
+Trust policy: identical to the PR role except
+
+```json
+"token.actions.githubusercontent.com:sub": "repo:<OWNER>/<REPO>:ref:refs/heads/main"
+```
+
+Permission policy: the PR role's policy **plus** `ecr:BatchDeleteImage` in the
+`EcrPushPull` statement (needed by `ecr-cleanup.yml` to prune a closed PR's
+tags).
+
+> If the existing role's trust policy is broader than `ref:refs/heads/main`
+> (e.g. `repo:<OWNER>/<REPO>:*`), tightening it is the load-bearing part of
+> this whole setup — do not skip it.
+
+## Rollout order
+
+The workflows select the role by event
+(`github.event_name == 'pull_request' && vars.AWS_GHA_PR_ROLE_ARN || vars.AWS_GHA_ROLE_ARN`),
+so the PR role must exist before the workflow change merges:
+
+1. Provision `gha-ci-pr` (trust + permission policies above) via IaC.
+2. Set the repo variable `AWS_GHA_PR_ROLE_ARN` to its ARN.
+3. Tighten `gha-ci-main`'s trust policy to `ref:refs/heads/main` only.
+4. Merge the workflow change. (Its own PR run already uses the new YAML, so
+   docker jobs on that PR fail until steps 1–2 are done — expected.)
+
+If `AWS_GHA_PR_ROLE_ARN` is ever unset, the expression falls back to the
+trusted role ARN — and the assume-role call then **fails** on the PR run,
+because the trusted trust policy rejects the `pull_request` sub. Misconfig
+fails closed; it does not silently re-open the hole.
+
+## Residual risk (known, accepted for now)
+
+IAM has no condition key for ECR image tag names, so the PR role's
+`ecr:PutImage` can still create or repoint any tag in the shared repos —
+including `latest` — if a PR deliberately rewrites the workflow. The split
+removes the destructive and deploy-adjacent capabilities and shrinks the blast
+radius; closing the tag-repointing gap needs one of:
+
+- **ECR tag immutability with exclusion filters** on the app repos (exclude
+  `cache-*` and `latest`, which must stay mutable), making `sha-*`/`pr-*` tags
+  write-once; or
+- publishing PR images to a **separate PR-only repo/namespace** the PR role is
+  scoped to, keeping the production repos out of reach of PR runs entirely.
+
+`release-deploy.yml` independently refuses anything not released by the release
+bot from a main-ancestor commit, so a repointed tag alone does not reach
+deployment.

--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -74,10 +74,17 @@ jobs:
         id: commit-info
         uses: ./.github/composite-actions/resolve-commit-info
 
+      # PR runs assume the least-privilege PR role (push/pull only, no delete).
+      # pull_request executes the PR branch's copy of this workflow, so YAML-side
+      # guards are advisory: the real boundary is IAM. The trusted role's trust
+      # policy is pinned to sub=repo:<org>/<repo>:ref:refs/heads/main, and the
+      # OIDC sub claim is set by the trigger — a PR-modified workflow presenting
+      # a sub of repo:…:pull_request cannot assume it. See
+      # .github/docs/aws-oidc-roles.md for the role definitions.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
-          role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
+          role-to-assume: ${{ github.event_name == 'pull_request' && vars.AWS_GHA_PR_ROLE_ARN || vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR

--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -52,10 +52,13 @@ jobs:
       security-events: write # upload SARIF to GitHub Security tab
 
     steps:
+      # PR runs assume the least-privilege PR role; the trusted role is pinned
+      # to main by its IAM trust policy (the OIDC sub claim is set by the
+      # trigger, not the YAML). See .github/docs/aws-oidc-roles.md.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
-          role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
+          role-to-assume: ${{ github.event_name == 'pull_request' && vars.AWS_GHA_PR_ROLE_ARN || vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -49,10 +49,13 @@ jobs:
         id: commit-info
         uses: ./.github/composite-actions/resolve-commit-info
 
+      # PR runs assume the least-privilege PR role; the trusted role is pinned
+      # to main by its IAM trust policy (the OIDC sub claim is set by the
+      # trigger, not the YAML). See .github/docs/aws-oidc-roles.md.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
-          role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
+          role-to-assume: ${{ github.event_name == 'pull_request' && vars.AWS_GHA_PR_ROLE_ARN || vars.AWS_GHA_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR

--- a/.github/workflows/ecr-cleanup.yml
+++ b/.github/workflows/ecr-cleanup.yml
@@ -36,8 +36,12 @@
 
 name: ecr-cleanup
 
+# Deliberate pull_request_target (see header): runs the base branch's reviewed
+# workflow code so the delete-capable trusted role is never exposed to a PR's
+# copy of this file. Safe because no PR-controlled code executes — base-branch
+# checkout only, PR metadata consumed as data via the API.
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [closed]
 
 concurrency:

--- a/.github/workflows/ecr-cleanup.yml
+++ b/.github/workflows/ecr-cleanup.yml
@@ -19,14 +19,25 @@
 # see the plan's follow-ups.
 #
 # Auth uses GitHub OIDC. Required repo variables: vars.AWS_REGION,
-# vars.AWS_GHA_ROLE_ARN. Fork PRs never receive OIDC/secrets (and so never
-# pushed images), so the job is skipped for them.
+# vars.AWS_GHA_ROLE_ARN. Fork PRs never receive OIDC (and so never pushed
+# images), so the job is skipped for them.
+#
+# pull_request_target, not pull_request: deleting images needs the trusted
+# role (ecr:BatchDeleteImage — deliberately NOT granted to the PR role), and a
+# plain pull_request run executes the PR branch's copy of this workflow with a
+# pull_request OIDC sub that the trusted role's trust policy rejects.
+# pull_request_target runs the base branch's copy with sub=ref:refs/heads/main,
+# so the delete capability is only ever exercised by reviewed workflow code.
+# Safe here because no PR-controlled code is executed: we check out the BASE
+# branch and only consume PR metadata (number, commit SHAs) via the API, passed
+# as data. Keep it that way — never check out or run the PR head in this file.
+# See .github/docs/aws-oidc-roles.md.
 # =============================================================================
 
 name: ecr-cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 concurrency:


### PR DESCRIPTION
## Problem

`pull_request` runs execute the **PR branch's copy** of the workflow files while holding `id-token: write` and the shared `AWS_GHA_ROLE_ARN`. Every YAML-side guarantee (Trivy scan gate, digest-only push, PR-scoped cache writes, `latest` head-of-main check) can be edited away by the PR itself — so a PR could exercise anything the role's IAM policy permits, including `ecr:BatchDeleteImage`.

## Fix

Enforce the boundary in IAM, using the OIDC `sub` claim — set by the trigger, unforgeable from YAML:

- **build/scan/publish** assume a new least-privilege PR role (`vars.AWS_GHA_PR_ROLE_ARN`, push/pull only, no delete) on `pull_request` events; the trusted role keeps main-only duty and its trust policy gets pinned to `ref:refs/heads/main`
- **ecr-cleanup** moves from `pull_request: [closed]` to `pull_request_target: [closed]` so its delete capability only ever runs the base branch's reviewed workflow code (it already checks out the base branch and consumes only PR metadata via the API — no PR code executes)
- **`.github/docs/aws-oidc-roles.md`** documents both roles' trust + permission policies, the rollout order, and the residual tag-repointing risk (`ecr:PutImage` has no tag-name condition key) with follow-up options (tag immutability exclusion filters, or a separate PR image namespace)

## Rollout (before merging)

1. Provision `gha-ci-pr` per the doc (trust: `sub = repo:<owner>/<repo>:pull_request`)
2. Set repo variable `AWS_GHA_PR_ROLE_ARN`
3. Tighten `gha-ci-main`'s trust policy to `ref:refs/heads/main` only — this is the load-bearing step

This PR's own docker jobs will fail until steps 1–2 are done (the PR run uses the new YAML). If the PR var is unset, the expression falls back to the trusted role, whose tightened trust policy rejects the `pull_request` sub — misconfig fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)