### PR TITLE
docs(ci): document that the scan gate is all-or-nothing across apps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,12 @@ jobs:
         APP_NAME=${{ matrix.target.app_name }}
       image_name: ${{ matrix.target.image_name }}
 
-  # Trivy gate: scan each app's per-arch digests. Failure skips that app's publish.
+  # Trivy gate: scan each app's per-arch digests. Deliberately all-or-nothing:
+  # the matrix legs aggregate into this single job's result, so ANY app's scan
+  # failure fails docker-scan and skips docker-publish for EVERY app — no image
+  # is tagged for this commit until all affected apps scan clean. Per-app
+  # isolation would need the build→scan→publish chain restructured into one
+  # per-app reusable workflow; failing closed is the chosen trade-off.
   docker-scan:
     needs: [deploy-matrix, docker-build]
     if: needs.deploy-matrix.outputs.has_apps == 'true'
@@ -97,7 +102,8 @@ jobs:
       app_slug: ${{ matrix.target.app_name }}
       image_name: ${{ matrix.target.image_name }}
 
-  # Only reached when the gate passes: tag the multi-arch manifest and attest.
+  # Only reached when the gate passes for every app: tag each multi-arch
+  # manifest and attest.
   docker-publish:
     needs: [deploy-matrix, docker-scan]
     if: needs.deploy-matrix.outputs.has_apps == 'true' && needs.docker-scan.result == 'success'


### PR DESCRIPTION
Comment-only change, no behavior difference.

`ci-cd.yml` claimed the Trivy gate's "failure skips **that app's** publish", but `docker-scan` is a single job whose matrix legs aggregate into one result — with `fail-fast: false`, any app's scan failure still makes `needs.docker-scan.result == 'failure'`, so `docker-publish` is skipped for **every** app and no image is tagged for the commit until all affected apps scan clean.

That fail-closed behavior is intended, so this fixes the comment to describe it (and notes that true per-app isolation would require restructuring build→scan→publish into a single per-app reusable workflow), plus tweaks the docker-publish comment to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)