### PR TITLE
fix(security): update undici and gate image scans on high severity

### DIFF
--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -40,7 +40,10 @@ on:
         description: 'Comma-separated severities that fail the build'
         required: false
         type: string
-        default: 'CRITICAL'
+        # HIGH included deliberately: with ignore_unfixed=true the gate only
+        # fails on findings that have a fix available, so a failure is always
+        # actionable (usually `pnpm update <pkg>` or a base-image bump).
+        default: 'CRITICAL,HIGH'
 
 jobs:
   scan:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6239,12 +6239,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.4.0:
-    resolution: {integrity: sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
@@ -7032,7 +7032,7 @@ snapshots:
       '@effect/sql': 0.33.11(@effect/experimental@0.44.11(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)(ioredis@5.10.1))(@effect/platform@0.96.2(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
       mime: 3.0.0
-      undici: 7.27.2
+      undici: 7.28.0
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -7044,7 +7044,7 @@ snapshots:
       effect: 4.0.0-beta.91
       ioredis: 5.10.1
       mime: 4.1.0
-      undici: 8.4.0
+      undici: 8.5.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11893,9 +11893,9 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
-  undici@8.4.0: {}
+  undici@8.5.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Why the HIGH gate failed before

The published effect-api-server image carried `undici@7.27.2` — a transitive production dependency of `@effect/platform-node` — with three **fixed** HIGH CVEs (CVE-2026-12151 WebSocket DoS, CVE-2026-6734 SOCKS5 info disclosure, CVE-2026-9697 SOCKS5 TLS MitM). Since it's transitive, nothing in our own `package.json` pointed at it, which made the gate failure look unresolvable.

## Fix

`@effect/platform-node` declares `undici: "^7.10.0"`, so `pnpm update -r undici` bumps the lockfile to 7.28.0 (and the beta platform-node's copy to 8.5.0) with no overrides and no `package.json` changes. Verified with trivy 0.72.0 locally:

- `gcr.io/distroless/nodejs24-debian13` (base image): **0** HIGH/CRITICAL
- `pnpm-lock.yaml`: 3 HIGH before → **0** after

`pnpm lint`, `typecheck`, and `test` all pass.

## Gate change

`_docker-security-scan.yml` default `severity_threshold` raised `CRITICAL` → `CRITICAL,HIGH`. `ignore_unfixed` stays `true`, so the gate only ever fails on findings that have a fix available — a failure always has a concrete remediation (usually `pnpm update <pkg>` or a base-image digest bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)