### PR TITLE
chore(monorepo): track effect 4.0 betas via pnpm catalog

### DIFF
--- a/apps/effect-mcp-server/package.json
+++ b/apps/effect-mcp-server/package.json
@@ -17,8 +17,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.91",
-    "effect": "4.0.0-beta.91"
+    "@effect/platform-node": "catalog:effect4",
+    "effect": "catalog:effect4"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "0.22.0",

--- a/one-version.config.json
+++ b/one-version.config.json
@@ -3,10 +3,10 @@
   "versionStrategy": "pin",
   "overrides": {
     "@effect/platform-node": {
-      "4.0.0-beta.91": ["@apps/effect-mcp-server"]
+      "catalog:effect4": ["@apps/effect-mcp-server"]
     },
     "effect": {
-      "4.0.0-beta.91": ["@apps/effect-mcp-server"]
+      "catalog:effect4": ["@apps/effect-mcp-server"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  effect4:
+    '@effect/platform-node':
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
+    effect:
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
+
 importers:
 
   .:
@@ -151,11 +160,11 @@ importers:
   apps/effect-mcp-server:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)
+        specifier: catalog:effect4
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
-        specifier: 4.0.0-beta.91
-        version: 4.0.0-beta.91
+        specifier: catalog:effect4
+        version: 4.0.0-beta.92
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 0.22.0
@@ -1031,11 +1040,11 @@ packages:
       '@effect/sql': ^0.51.1
       effect: ^3.21.2
 
-  '@effect/platform-node-shared@4.0.0-beta.91':
-    resolution: {integrity: sha512-JX++yhomaOEpQmnTYuhn+pKAgKg5MQvycAf1rXGtyVKi202Nc5nK37xbywDcugfwrc1FrPxrxa3BY3lbSc74cw==}
+  '@effect/platform-node-shared@4.0.0-beta.92':
+    resolution: {integrity: sha512-156ADSfmWcqz0mC8VxlHN9IHyT97AbYsBc3wJxyz2ceiWyGJOWkIRd6H/n5Be4hd6dQ4IegSt6J3HinBIJ9S/A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.92
 
   '@effect/platform-node@0.107.0':
     resolution: {integrity: sha512-VWUD9SCcnsrXYqED2jIwDHHDGb3QePNsHlX7HfqQGD2/AgnfX9jNnecaFrJj7Rf2gK5VbRE+i/2oNFoC/DkhcA==}
@@ -1046,11 +1055,11 @@ packages:
       '@effect/sql': ^0.51.1
       effect: ^3.21.2
 
-  '@effect/platform-node@4.0.0-beta.91':
-    resolution: {integrity: sha512-gP7Xlmce/HJxg3WaacmrRMJtRw2j6uJ4UrLEDy596tokdXcMoakz2oAtULSXiLzihLeQnt9nrm9K5nHhqKdBdA==}
+  '@effect/platform-node@4.0.0-beta.92':
+    resolution: {integrity: sha512-ZNcwKqBb99yw+cj+KQBMgw0xoQl3GDbUtQjnN3cLsIRpfYS/AVcSp4wfURMczvX5PzoR131yOWkqds5Vmm5tLg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.91
+      effect: ^4.0.0-beta.92
       ioredis: ^5.7.0
 
   '@effect/platform@0.96.2':
@@ -4106,8 +4115,8 @@ packages:
   effect@3.21.4:
     resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
 
-  effect@4.0.0-beta.91:
-    resolution: {integrity: sha512-FFlkWiy1QK4xuHd/nui9LKD/5qkpSHJdMcbsEY7jl9V27+txye6W+RAIlmWjuA2vvtUyZmzGKarVtdU0l1pdBQ==}
+  effect@4.0.0-beta.92:
+    resolution: {integrity: sha512-et6Fy8X9cxhzV/w4U372lB7YCP/B9a8FYVxlx9UMzSgnmwWKxpldnaHz7mHpZHh+OU+ENhU9DO/rTAakmT0sEA==}
 
   electron-to-chromium@1.5.378:
     resolution: {integrity: sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==}
@@ -7014,10 +7023,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.91(effect@4.0.0-beta.91)':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.91
+      effect: 4.0.0-beta.92
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -7038,10 +7047,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.91(effect@4.0.0-beta.91)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.91(effect@4.0.0-beta.91)
-      effect: 4.0.0-beta.91
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.4.0
@@ -9599,7 +9608,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effect@4.0.0-beta.91:
+  effect@4.0.0-beta.92:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,15 @@ engineStrict: true
 #  immediately pulled in before the community detects it.
 minimumReleaseAge: 4320 # 72 hours
 
+# Single source of truth for the Effect 4.0 beta line: workspaces declare
+# `catalog:effect4`, so bumping a beta is a one-line edit here — package.json
+# and one-version.config.json (which keys its override on the literal
+# `catalog:effect4` string) stay untouched.
+catalogs:
+  effect4:
+    '@effect/platform-node': 4.0.0-beta.92
+    effect: 4.0.0-beta.92
+
 packages:
   - 'apps/*'
   - 'packages/*'
@@ -42,7 +51,11 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - 'chokidar@4.0.3'
   - 'semver@6.3.1'
-  - 'effect@4.0.0-beta.91'
-  - '@effect/platform-node@4.0.0-beta.91'
-  - '@effect/platform-node-shared@4.0.0-beta.91'
+  # Bare names (no version) exclude every version: pnpm only accepts exact
+  # versions here (no ranges), so this is the only way to track the Effect 4.0
+  # betas without editing this list on each release. Rollback protection is off
+  # for these three packages only — re-pin to exact versions once 4.0.0 stable lands.
+  - 'effect'
+  - '@effect/platform-node'
+  - '@effect/platform-node-shared'
   - 'tailwind-merge@2.6.1'


### PR DESCRIPTION
## Problem

Each Effect 4.0 beta bump required coordinated edits in three files:

1. `apps/effect-mcp-server/package.json` — the pinned beta version
2. `one-version.config.json` — override keys are exact-string lookups (`overrides[pkg][version]`), no ranges or wildcards on the version key
3. `pnpm-workspace.yaml` `trustPolicyExclude` — pnpm's parser (`parseExactVersionsUnion`, verified in the 11.9.0 dist) accepts exact versions or `||` unions only; ranges like `4.0.0-beta.*` are rejected

## Change

- **New `effect4` catalog** in `pnpm-workspace.yaml` — the single source of truth for the beta line (bumped to `4.0.0-beta.92` here). Future bumps are a one-line edit + `pnpm install`.
- **`effect-mcp-server` declares `catalog:effect4`** for `effect` and `@effect/platform-node`. one-version 0.3.1 has no catalog awareness and compares raw specifier strings — so the one-version override key becomes the stable literal `catalog:effect4` and never changes again. (`catalog:` also passes its `pin`-strategy heuristics.)
- **`trustPolicyExclude` switches to bare package names** for `effect`, `@effect/platform-node`, `@effect/platform-node-shared` — the only bump-proof form pnpm supports. Rollback (`no-downgrade`) protection is off for these three packages only, noted in a comment with a reminder to re-pin at 4.0.0 stable.

## Verification

- `pnpm install` resolves cleanly; lockfile importers now reference `catalog:effect4` → `4.0.0-beta.92`
- `one-version check` passes; `pnpm lint`, `typecheck`, `test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)