### PR TITLE
chore(monorepo): hoist codegen outputs to root turbo config

### DIFF
--- a/apps/agentic-ai-example-app/turbo.json
+++ b/apps/agentic-ai-example-app/turbo.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["//"],
-  "tasks": {
-    "codegen": {
-      "outputs": [".svelte-kit/**"]
-    }
-  }
-}

--- a/apps/ha-dashboard/turbo.json
+++ b/apps/ha-dashboard/turbo.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["//"],
-  "tasks": {
-    "codegen": {
-      "outputs": [".svelte-kit/**"]
-    }
-  }
-}

--- a/apps/sveltekit-example-app/turbo.json
+++ b/apps/sveltekit-example-app/turbo.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["//"],
-  "tasks": {
-    "codegen": {
-      "outputs": [".svelte-kit/**"]
-    }
-  }
-}

--- a/packages/ui-lib-svelte/turbo.json
+++ b/packages/ui-lib-svelte/turbo.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["//"],
-  "tasks": {
-    "build": {
-      "outputs": [".svelte-kit/**"]
-    }
-  }
-}

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
   ],
   "tasks": {
     "codegen": {
-      "dependsOn": ["^codegen"]
+      "dependsOn": ["^codegen"],
+      "outputs": [".svelte-kit/**"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

Consolidates the per-workspace `turbo.json` files that only re-declared `codegen` outputs into a single declaration on the root `codegen` task.

- Removes the four `extends: ["//"]` workspace configs (`agentic-ai-example-app`, `ha-dashboard`, `sveltekit-example-app`, `ui-lib-svelte`), each of which only re-declared `codegen` outputs.
- Declares `"outputs": [".svelte-kit/**"]` on the root `codegen` task, so it applies to every workspace by inheritance.
- Fixes a latent bug in `ui-lib-svelte`: its stale config pointed `outputs` at a nonexistent `build` task (there is no `build` task in this repo), so its `.svelte-kit` output was never being cached. It now caches via the root `codegen` task.

## Verification

- `pnpm codegen` → second run reports `FULL TURBO` (4/4 cached), confirming outputs are now cached correctly.
- `pnpm lint` → 21/21 successful
- `pnpm typecheck` → 20/20 successful
- `pnpm test` → 20/20 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)