### PR TITLE
ci(prepare): persist turbo local cache across runs

### DIFF
--- a/.github/composite-actions/prepare/action.yml
+++ b/.github/composite-actions/prepare/action.yml
@@ -20,6 +20,20 @@ runs:
       shell: bash
       run: pnpm install --ignore-scripts --frozen-lockfile
 
+    # Persist Turbo's local cache across runs so unchanged tasks replay
+    # instead of re-executing. Scoped per job (github.job) so the parallel
+    # code-quality jobs don't clobber each other's task outputs; the sha
+    # suffix keeps keys write-unique, and restore-keys falls back to the
+    # newest prior cache for this job — which GitHub already prefers from
+    # the same branch/PR, then the base branch.
+    - name: Cache Turbo local artifacts
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-${{ github.job }}-
+
     - name: Copy env files
       shell: bash
       run: find apps -name ".env.example" -execdir cp {} .env \;

--- a/.github/composite-actions/turbo-cache-summary/action.yml
+++ b/.github/composite-actions/turbo-cache-summary/action.yml
@@ -1,0 +1,39 @@
+name: Turbo cache summary
+description: Writes the latest Turbo run's cache hit/miss breakdown to the job summary
+
+runs:
+  using: composite
+  steps:
+    - name: Write Turbo cache summary
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Newest run summary produced by `turbo run ... --summarize`. Each job
+        # clears .turbo/runs before running, so at most one file exists here.
+        f=$(ls -t .turbo/runs/*.json 2>/dev/null | head -n1 || true)
+
+        {
+          echo "### Turbo cache — ${{ github.job }}"
+          if [[ -z "${f}" ]]; then
+            echo "_No Turbo run summary found._"
+            exit 0
+          fi
+
+          attempted=$(jq '.execution.attempted' "${f}")
+          cached=$(jq '.execution.cached' "${f}")
+          if [[ "${attempted}" -eq 0 ]]; then
+            echo "_No affected tasks — nothing to run._"
+            exit 0
+          fi
+
+          echo ""
+          echo "**${cached}/${attempted} tasks served from cache.**"
+          echo ""
+          echo "| Task | Cache | Source | Time saved |"
+          echo "| --- | --- | --- | --- |"
+          jq -r '
+            .tasks[]
+            | "| \(.taskId) | \(.cache.status) | \(.cache.source // "-") | \(.cache.timeSaved // 0) ms |"
+          ' "${f}"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_code-quality.yml
+++ b/.github/workflows/_code-quality.yml
@@ -21,7 +21,13 @@ jobs:
         uses: ./.github/composite-actions/prepare
 
       - name: Run ESLint check
-        run: pnpm exec turbo run lint --affected
+        run: |
+          rm -rf .turbo/runs
+          pnpm exec turbo run lint --affected --summarize
+
+      - name: Summarize Turbo cache
+        if: always()
+        uses: ./.github/composite-actions/turbo-cache-summary
 
       - name: Run Prettier check
         run: pnpm run format:check
@@ -43,7 +49,13 @@ jobs:
         uses: ./.github/composite-actions/prepare
 
       - name: Run type checks
-        run: pnpm exec turbo run typecheck --affected
+        run: |
+          rm -rf .turbo/runs
+          pnpm exec turbo run typecheck --affected --summarize
+
+      - name: Summarize Turbo cache
+        if: always()
+        uses: ./.github/composite-actions/turbo-cache-summary
 
   test:
     name: Unit Test
@@ -62,4 +74,10 @@ jobs:
         uses: ./.github/composite-actions/prepare
 
       - name: Run unit tests
-        run: pnpm exec turbo run test --affected -- --reporter=default
+        run: |
+          rm -rf .turbo/runs
+          pnpm exec turbo run test --affected --summarize -- --reporter=default
+
+      - name: Summarize Turbo cache
+        if: always()
+        uses: ./.github/composite-actions/turbo-cache-summary


### PR DESCRIPTION
## Summary

Adds `actions/cache` for Turbo's local `.turbo` directory in the `prepare` composite action, so unchanged Turbo tasks replay from cache instead of re-executing on subsequent CI runs.

- Caches `.turbo`, keyed `turbo-<os>-<job>-<sha>` with `restore-keys: turbo-<os>-<job>-`.
- **Per-job scoping (`github.job`)** is deliberate: `_code-quality.yml` runs `lint`, `type-check`, and `test` as three parallel jobs, each doing `turbo run <task> --affected` on its own runner. A shared key would let only the first job to finish write the cache, dropping the others' task outputs. Scoping per job keeps each job's outputs.
- The `sha` suffix keeps keys write-unique (caches are immutable once written); `restore-keys` falls back to the newest prior cache for that job — which GitHub already prefers from the same branch/PR, then the base branch. That's the "subsequent pushes to the same PR" win.

### Why `actions/cache` and not `upload`/`download-artifact`

Artifacts are for passing files between jobs in a single run; they have no native "restore the newest from a prior run" and no branch/PR scoping. `actions/cache`'s `restore-keys` prefix fallback gives both for free.

## Notes

- Pinned to `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0); `path`/`key`/`restore-keys` inputs verified against the action's `action.yml`.
- First run after merge is still a full cache miss (nothing to restore yet); the payoff appears on second and later pushes.

## Verification

- `pnpm lint` → 21/21 successful
- `pnpm typecheck` → 20/20 successful
- `pnpm test` → 20/20 successful
- YAML formatting validated via Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)