### PR TITLE
chore(monorepo): track dockerfile as a turbo global dependency

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [
+    "Dockerfile",
     "toolchain/typescript-config/**",
     "toolchain/eslint-config/**",
     "toolchain/vitest-config/**"


### PR DESCRIPTION
## What

Adds `Dockerfile` to `globalDependencies` in `turbo.json`.

## Why

The repo-root `Dockerfile` was invisible to Turbo's affected-package graph. Because the `ci-cd` `docker-build → docker-scan → docker-publish` chain is gated on Turbo-affected apps (`has_apps`), a commit touching **only** the `Dockerfile` marked no packages affected — so CI built and published **no** new images, even though the change affects the build/runtime of every containerized app. Published images stayed stale until an unrelated package change re-triggered a build.

Adding it to `globalDependencies` folds the `Dockerfile` into every task's global hash, so any change marks all packages affected and triggers a rebuild of every deployable app.

## Trade-off

As a global dependency, a `Dockerfile` edit also busts the `lint`/`test`/`typecheck` caches across all packages on the next run (one re-run). This matches the existing behavior of the `toolchain/*-config` global deps and is the correct trade-off for a repo-wide build recipe.

## Verification

`turbo run typecheck --dry=json` now lists `Dockerfile` under `globalCacheInputs.files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)