### PR TITLE
fix(ci): address docker pipeline review findings

### DIFF
--- a/.github/workflows/_docker-build-stage.yml
+++ b/.github/workflows/_docker-build-stage.yml
@@ -6,6 +6,12 @@
 # downstream (the gate) and only the `_ecr-publish.yml` job stitches them into a
 # tagged multi-arch manifest once the scan passes. Each leg uploads its digest as
 # an artifact (`digests-<platform>`) so scan + publish can resolve the bytes.
+#
+# Note: PR runs publish real sha-<head sha> tags for unreviewed (same-repo)
+# branches. Their containment relies on squash-only merges: PR head SHAs never
+# become ancestors of main, so release-create.yml rejects them and
+# ecr-cleanup.yml deletes them when the PR closes. If the repo ever allows
+# merge-commit merges, revisit this (e.g. tag PR images pr-<n>-sha-<sha>).
 
 name: _docker-build-stage
 
@@ -126,9 +132,12 @@ jobs:
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
       - name: Sanitize platform name
+        env:
+          # Via env, not inline expansion — keeps the no-inline-interpolation
+          # discipline uniform even though the matrix values are static.
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
 
       # PR builds must not write the cache that main builds consume: an
       # unreviewed PR could otherwise seed poisoned layers that the next main

--- a/.github/workflows/_docker-security-scan.yml
+++ b/.github/workflows/_docker-security-scan.yml
@@ -53,6 +53,11 @@ jobs:
       contents: read
       id-token: write # assume the AWS role via OIDC
       security-events: write # upload SARIF to GitHub Security tab
+    env:
+      # ghcr.io rate-limits the Trivy DBs hard under CI fan-out (every matrix
+      # leg pulls them). Prefer the ECR Public mirror, fall back to ghcr.
+      TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
+      TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
 
     steps:
       - name: Configure AWS credentials
@@ -67,13 +72,21 @@ jobs:
 
       # Resolve this app's per-arch image refs from its digest artifacts. Each
       # artifact holds a single empty file named after the digest hex (no
-      # sha256: prefix). Under a matrix, sibling apps upload their own
-      # `digests-<app>-*` artifacts, so the pattern is scoped to this app.
-      - name: Download digest artifacts
+      # sha256: prefix). Downloaded by exact name (one per platform, mirroring
+      # the build matrix) rather than a `digests-<app>-*` pattern: under a
+      # matrix, an app slug that is a prefix of a sibling's (e.g. `api` and
+      # `api-server`) would make the pattern match the sibling's artifacts too.
+      - name: Download amd64 digest artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: /tmp/digests
-          pattern: digests-${{ inputs.app_slug }}-*
+          path: /tmp/digests/digests-${{ inputs.app_slug }}-linux-amd64
+          name: digests-${{ inputs.app_slug }}-linux-amd64
+
+      - name: Download arm64 digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests/digests-${{ inputs.app_slug }}-linux-arm64
+          name: digests-${{ inputs.app_slug }}-linux-arm64
 
       - name: Resolve per-arch image refs
         env:
@@ -118,7 +131,10 @@ jobs:
         if: always() && hashFiles('trivy-results.sarif') != '' # Upload results even if the scan fails
         with:
           sarif_file: 'trivy-results.sarif'
-          category: trivy-container
+          # Per-app category: code scanning keys analyses by (ref, tool,
+          # category), so a shared category would let each matrix leg's upload
+          # supersede the previous app's results for the same commit.
+          category: trivy-container-${{ inputs.app_slug }}
 
       # -------------------------------------------------------------------
       # Severity gate (amd64): fail on configured severity threshold

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -44,6 +44,10 @@ jobs:
           # merge ref) so the recomputed tags/labels describe the commit the
           # image bytes were actually built from.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Full history: the latest-ordering check below runs
+          # `git merge-base --is-ancestor` against the commit currently
+          # published as `latest`.
+          fetch-depth: 0
 
       - name: Resolve commit SHA and build date
         id: commit-info
@@ -69,33 +73,63 @@ jobs:
         run: |
           echo "repo=${REGISTRY}/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Download digest artifacts
+      # Downloaded by exact name (one per platform, mirroring the build matrix)
+      # rather than a `digests-<app>-*` pattern: the manifest step below stitches
+      # EVERY downloaded digest into this app's manifest, so an app slug that is
+      # a prefix of a sibling's (e.g. `api` and `api-server`) would silently pull
+      # the sibling's digests in via the pattern. Exact names also fail loudly if
+      # a build leg's artifact is missing.
+      - name: Download amd64 digest artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
-          pattern: digests-${{ inputs.app_slug }}-*
-          merge-multiple: true
+          name: digests-${{ inputs.app_slug }}-linux-amd64
+
+      - name: Download arm64 digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests
+          name: digests-${{ inputs.app_slug }}-linux-arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Main runs are concurrency-grouped per commit (see ci-cd.yml), so two can
-      # publish in parallel. Only the run whose commit is still the head of
-      # main applies `latest` — otherwise an older commit's slower run
-      # finishing last would repoint `latest` backwards. When this run skips
-      # it, the newer commit's own run applies `latest` instead.
-      - name: Check whether this commit is still the head of main
-        id: head-check
+      # publish this app in parallel. Apply `latest` only if this commit is a
+      # descendant of the commit `latest` currently points at (read from the
+      # org.opencontainers.image.revision label, same as release-create.yml) —
+      # otherwise an older commit's slower run finishing last would repoint
+      # `latest` backwards. A repo-wide head-of-main check is NOT enough: if the
+      # newer head commit doesn't affect this app (or fails its scan gate), its
+      # run never publishes this app, and `latest` would stay stale forever.
+      - name: Check whether this commit should take latest
+        id: latest-check
         if: github.event_name == 'push'
         env:
+          REPO: ${{ steps.repo.outputs.repo }}
           SHA: ${{ steps.commit-info.outputs.full_sha }}
         run: |
           set -euo pipefail
-          head="$(git ls-remote origin refs/heads/main | cut -f1)"
-          is_head=false
-          [[ "$head" == "$SHA" ]] && is_head=true
-          echo "is_head=${is_head}" >> "$GITHUB_OUTPUT"
-          echo "Commit ${SHA} vs main head ${head} — is_head=${is_head}"
+          apply_latest=true
+          reason="no current latest — this commit takes it"
+
+          if manifest="$(docker buildx imagetools inspect "${REPO}:latest" --format '{{json .}}' 2>/dev/null)"; then
+            current_sha="$(jq -r '[.. | objects | select(has("org.opencontainers.image.revision"))
+                                   | .["org.opencontainers.image.revision"]] | first // empty' <<< "$manifest")"
+            if [[ -z "$current_sha" ]]; then
+              reason="current latest has no revision label — assuming this pipeline should own it"
+            elif ! git cat-file -e "${current_sha}^{commit}" 2>/dev/null; then
+              reason="current latest revision ${current_sha} not found in history — assuming this commit is newer"
+            elif git merge-base --is-ancestor "$current_sha" "$SHA"; then
+              reason="current latest revision ${current_sha} is an ancestor of ${SHA}"
+            else
+              apply_latest=false
+              reason="current latest revision ${current_sha} is NOT an ancestor of ${SHA} — a newer commit already took latest"
+            fi
+          fi
+
+          echo "apply_latest=${apply_latest}" >> "$GITHUB_OUTPUT"
+          echo "apply_latest=${apply_latest}: ${reason}"
 
       - name: Compute tags and labels
         id: meta
@@ -105,7 +139,7 @@ jobs:
           tags: |
             type=raw,value=sha-${{ steps.commit-info.outputs.full_sha }}
             type=ref,event=pr,prefix=pr-
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.head-check.outputs.is_head == 'true' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.latest-check.outputs.apply_latest == 'true' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.commit-info.outputs.full_sha }}
@@ -130,17 +164,16 @@ jobs:
 
       - name: Inspect manifest and capture digest
         id: inspect
+        env:
+          # Via env, not inline expansion: the repo derives from a repo-authored
+          # deploy.json, so it must not reach the shell as code.
+          SHA_REF: ${{ steps.repo.outputs.repo }}:sha-${{ steps.commit-info.outputs.full_sha }}
         run: |
-          digest=$(docker buildx imagetools inspect \
-            ${{ steps.repo.outputs.repo }}:sha-${{ steps.commit-info.outputs.full_sha }} \
-            --format '{{.Manifest.Digest}}')
+          set -euo pipefail
+          digest=$(docker buildx imagetools inspect "$SHA_REF" --format '{{.Manifest.Digest}}')
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-          docker buildx imagetools inspect \
-            ${{ steps.repo.outputs.repo }}:sha-${{ steps.commit-info.outputs.full_sha }} \
-            > /tmp/imagetools-inspect.txt
-          docker buildx imagetools inspect \
-            ${{ steps.repo.outputs.repo }}:sha-${{ steps.commit-info.outputs.full_sha }} \
-            --format '{{json .}}' | jq '.' > /tmp/imagetools-inspect.json
+          docker buildx imagetools inspect "$SHA_REF" > /tmp/imagetools-inspect.txt
+          docker buildx imagetools inspect "$SHA_REF" --format '{{json .}}' | jq '.' > /tmp/imagetools-inspect.json
 
       # SLSA build provenance attached to the ECR image as an OCI referrer.
       - name: Attest build provenance
@@ -151,20 +184,27 @@ jobs:
           push-to-registry: true
 
       - name: Summary
+        env:
+          # Via env, not inline expansion: the repo (and the tags derived from
+          # it) comes from a repo-authored deploy.json, so it must not reach the
+          # shell as code.
+          REPO: ${{ steps.repo.outputs.repo }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           {
             echo "### Published to ECR"
             echo ""
-            echo "**Digest:** \`${{ steps.inspect.outputs.digest }}\`"
+            echo "**Digest:** \`${DIGEST}\`"
             echo ""
             echo "**Pinned ref:**"
             echo "\`\`\`"
-            echo "${{ steps.repo.outputs.repo }}@${{ steps.inspect.outputs.digest }}"
+            echo "${REPO}@${DIGEST}"
             echo "\`\`\`"
             echo ""
             echo "**Tags:**"
             echo "\`\`\`"
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "$TAGS"
             echo "\`\`\`"
             echo ""
             echo "<details><summary>Manifest inspect</summary>"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ on:
 # queued run when merges land quickly, leaving that commit with no sha-<sha>
 # image (unreleasable) and a spurious red X. Parallel main runs racing to tag
 # `latest` are handled in _ecr-publish.yml, which only applies `latest` when
-# its commit is still the head of main.
+# the commit `latest` currently points at is an ancestor of its own commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Fixes from a comprehensive review of the ci-cd workflow chain (`ci-cd.yml` + its reusable workflows + composite actions, cross-checked against `release-create` / `release-deploy` / `ecr-cleanup`).

## Changes

### 1. Per-app SARIF category (`_docker-security-scan.yml`) — bug
Code scanning keys analyses by (ref, tool, category). With the fixed `trivy-container` category, each `docker-scan` matrix leg's upload superseded the previous app's results for the same commit — the Security tab only ever showed the last app scanned. Now `trivy-container-<app_slug>`.

### 2. Exact-name digest artifact downloads (`_ecr-publish.yml`, `_docker-security-scan.yml`) — latent bug
The `digests-<slug>-*` download pattern would match a sibling app whose slug is prefixed by this one (e.g. `api` and `api-server`). In the publish job that's silent corruption: the manifest step stitches **every** downloaded digest into this app's manifest. Both jobs now download the two per-platform artifacts by exact name, which also fails loudly if a build leg's artifact is missing.

### 3. Per-app `latest` ordering check (`_ecr-publish.yml`) — gap
The old head-of-main check assumed "the newer commit's own run applies `latest` instead" — false when the newer commit doesn't affect this app (or fails its scan gate), leaving that app's `latest` stale even though a newer `sha-` image exists (and `release-create` defaults to `latest`). Now the run inspects the current `:latest`, extracts its `org.opencontainers.image.revision` label (same technique as `release-create`), and applies `latest` iff that commit is an ancestor of this run's commit. This is per-app-correct and still handles the parallel-main-runs race the head check was built for. Requires full-history checkout for `merge-base --is-ancestor`.

The ordering logic was dry-run locally against real repo ancestry (stubbed `docker`): older-latest → apply, newer-latest → skip, same commit → apply (idempotent re-run), unknown/missing label → apply with a warning.

### 4. Trivy DB mirror (`_docker-security-scan.yml`) — flakiness
ghcr.io rate-limits the Trivy DBs under matrix fan-out; prefer `public.ecr.aws` with ghcr fallback via `TRIVY_DB_REPOSITORY` / `TRIVY_JAVA_DB_REPOSITORY`.

### 5. Env-routing consistency (`_docker-build-stage.yml`, `_ecr-publish.yml`)
A few `run:` blocks still interpolated `${{ }}` inline (`matrix.platform`, `steps.repo.outputs.repo` — the latter derives from repo-authored `deploy.json`, exactly the value other steps deliberately route via `env`). All routed through `env:` now, plus a comment documenting that PR sha-tag containment relies on squash-only merges.

## Verification
- YAML parse-validated; Prettier clean.
- New shell logic `bash -n` checked; `latest`-ordering behavior exercised against real git ancestry for all four cases (see above).
- The PR run itself exercises 1, 2 (PR path), and 5; the post-merge main run exercises 3 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)