### PR TITLE
fix(ci): address dockerfile review findings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,17 @@
+# Unlike .gitignore, a bare name here only matches at the context root, so
+# workspace-level artifacts need the `**/` prefix to be excluded at any depth.
 .git
 .github
 .gitignore
-node_modules
+**/node_modules
 
 .husky
-.turbo
+**/.turbo
 
-.svelte-kit
-build
+**/.svelte-kit
+**/build
 
-.env
-.env.*
+**/coverage
+
+**/.env
+**/.env.*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,15 @@ updates:
       # Match the repo's commitlint convention (subject stays lowercase:
       # "ci(github-actions): bump ...").
       prefix: ci(github-actions)
+  - package-ecosystem: docker
+    directories:
+      - /
+    schedule:
+      interval: weekly
+    # One grouped PR so the builder image tag and the digest-pinned distroless
+    # runtime image move together instead of drifting across separate PRs.
+    groups:
+      docker:
+        patterns: ['*']
+    commit-message:
+      prefix: ci(docker)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builds a single app (APP_NAME) from the monorepo. Works for any workspace whose
-# production bundle is produced by `vite build`. The default CMD runs `node build`
-# (e.g. sveltekit adapter-node output); override it for apps with a different entry.
+# production bundle is produced by `vite build`. The runtime runs `node .`, so the
+# app's package.json `main` field must point at its built server entry.
 FROM node:24.17.0-trixie-slim AS base
 RUN corepack enable pnpm
 WORKDIR /repo
@@ -50,4 +50,7 @@ ENV APP_NAME=${APP_NAME} \
 
 EXPOSE 3000
 ENV PORT=3000
-CMD ["build"]
+# `node .` resolves the app's entry point from the `main` field of its package.json,
+# so each app declares where its server entry lives instead of the Dockerfile
+# assuming a fixed output path
+CMD ["."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ COPY --link --from=pruner /repo/out/full/ .
 RUN pnpm exec turbo run codegen --filter=@apps/${APP_NAME}...
 RUN pnpm --filter=@apps/${APP_NAME} exec vite build
 RUN pnpm --filter=@apps/${APP_NAME} deploy --legacy --prod out
+# Fail the build if the deployed package can't be started with `node .` in the runtime
+# stage: `main` must be declared and the file it points at must have been packed
+RUN node -e "const p = require('/repo/out/package.json'); \
+    if (!p.main) throw new Error('package.json needs a main field pointing at the built server entry'); \
+    require('fs').accessSync('/repo/out/' + p.main)"
 
 # ---- Minimal runtime ----
 # Distroless publishes no Node patch-version tags, so pin by digest to keep the runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
 # Now the actual source
 COPY --link --from=pruner /repo/out/full/ .
-# Inclusive filter (`...`) runs codegen for the app itself and all upstream workspaces
-RUN pnpm exec turbo run codegen --filter=@apps/${APP_NAME}...
+RUN pnpm exec turbo run codegen --filter=@apps/$APP_NAME^...
 RUN pnpm --filter=@apps/${APP_NAME} exec vite build
 RUN pnpm --filter=@apps/${APP_NAME} deploy --legacy --prod out
 # Fail the build if the deployed package can't be started with `node .` in the runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Builds a single SvelteKit app (APP_NAME) from the monorepo. The app must use
-# @sveltejs/adapter-node: the builder runs `vite build` and the runtime executes the
-# adapter's `build/index.js` output. Other adapters and non-SvelteKit apps won't work.
+# Builds a single app (APP_NAME) from the monorepo. Works for any workspace whose
+# production bundle is produced by `vite build`. The default CMD runs `node build`
+# (e.g. sveltekit adapter-node output); override it for apps with a different entry.
 FROM node:24.17.0-trixie-slim AS base
 RUN corepack enable pnpm
 WORKDIR /repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Builds a single SvelteKit app (APP_NAME) from the monorepo. The app must use
+# @sveltejs/adapter-node: the builder runs `vite build` and the runtime executes the
+# adapter's `build/index.js` output. Other adapters and non-SvelteKit apps won't work.
 FROM node:24.17.0-trixie-slim AS base
 RUN corepack enable pnpm
 WORKDIR /repo
@@ -6,6 +9,7 @@ WORKDIR /repo
 FROM base AS pruner
 ARG APP_NAME
 COPY . .
+RUN test -n "${APP_NAME}" || { echo "APP_NAME build arg is required" >&2; exit 1; }
 RUN TURBO_VERSION=$(node -p "require('./package.json').devDependencies.turbo") && \
     pnpm dlx turbo@${TURBO_VERSION} prune @apps/${APP_NAME} --docker
 
@@ -19,15 +23,20 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
 # Now the actual source
 COPY --link --from=pruner /repo/out/full/ .
-RUN pnpm exec turbo run codegen --filter=@apps/$APP_NAME^...
+# Inclusive filter (`...`) runs codegen for the app itself and all upstream workspaces
+RUN pnpm exec turbo run codegen --filter=@apps/${APP_NAME}...
 RUN pnpm --filter=@apps/${APP_NAME} exec vite build
 RUN pnpm --filter=@apps/${APP_NAME} deploy --legacy --prod out
 
 # ---- Minimal runtime ----
-FROM gcr.io/distroless/nodejs24-debian13 AS deployer
+# Distroless publishes no Node patch-version tags, so pin by digest to keep the runtime
+# Node version reproducible and in step with the builder image above.
+FROM gcr.io/distroless/nodejs24-debian13@sha256:ef5f3caf80da1630edd1a4df7b307a8f7d4553f8eec1dd29852b76e793593903 AS deployer
 WORKDIR /app
 ENV NODE_ENV=production
-COPY --chown=nonroot:nonroot --from=builder /repo/out/ .
+# Left root-owned deliberately: the app only reads its own files, and the nonroot
+# runtime user must not be able to modify them
+COPY --from=builder /repo/out/ .
 USER nonroot
 
 ARG APP_NAME=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Builds a single app (APP_NAME) from the monorepo. Works for any workspace whose
 # production bundle is produced by `vite build`. The runtime runs `node .`, so the
-# app's package.json `main` field must point at its built server entry.
+# app's package.json must declare both:
+#   "main": pointing at its built server entry (e.g. "build/index.js")
+#   "files": including the build output directory (e.g. "files": ["build"]),
+#            otherwise `pnpm deploy` won't copy the bundle into the runtime image
 FROM node:24.17.0-trixie-slim AS base
 RUN corepack enable pnpm
 WORKDIR /repo

--- a/apps/effect-api-server/package.json
+++ b/apps/effect-api-server/package.json
@@ -5,6 +5,7 @@
   "description": "Effect Node API Server",
   "license": "UNLICENSED",
   "type": "module",
+  "main": "build/index.js",
   "files": [
     "build"
   ],

--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -5,6 +5,9 @@
   "description": "SvelteKit Example App",
   "type": "module",
   "main": "build/index.js",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "clean": "del .turbo coverage .svelte-kit build",
     "codegen": "svelte-kit sync",

--- a/apps/sveltekit-example-app/package.json
+++ b/apps/sveltekit-example-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "SvelteKit Example App",
   "type": "module",
+  "main": "build/index.js",
   "scripts": {
     "clean": "del .turbo coverage .svelte-kit build",
     "codegen": "svelte-kit sync",


### PR DESCRIPTION
Addresses findings from a Dockerfile review:

1. **Reproducible runtime image** — `gcr.io/distroless/nodejs24-debian13` is a floating tag while the builder is pinned to `24.17.0`; the runtime is now pinned by its multi-arch index digest (linux/amd64, arm64, s390x, ppc64le).
2. **Documented contract** — a header comment states the Dockerfile builds any workspace whose production bundle comes from `vite build`. The runtime is `CMD ["."]` (`node .`): each app declares `main` pointing at its built server entry and `files` including the build output directory (required for `pnpm deploy` to copy the bundle). Both added to `sveltekit-example-app`.
3. **Fail-fast guard** — a missing or empty `APP_NAME` build arg now fails immediately with `APP_NAME build arg is required` instead of a cryptic `turbo prune` error.
4. **Hardened file ownership** — dropped `--chown=nonroot:nonroot`; app files stay root-owned and read-only to the nonroot runtime user.

5. **Deterministic build context** — bare names in `.dockerignore` only match at the context root, so nested `node_modules`, `.turbo`, `.svelte-kit`, `build`, `coverage`, and `.env` files (several exist under `apps/*` and `packages/*`) were riding into the build context. All are now `**/`-prefixed, so stale local builds and env files can no longer leak into images.

6. **Runnable-output assertion** — after `pnpm deploy`, the builder verifies the deployed package declares `main` and that the file it points at was actually packed, failing the build with a clear error instead of producing an image that dies at container start. Staying on `deploy --legacy` (non-legacy requires `injectWorkspacePackages`, a workspace-wide semantics change); this assertion provides the fail-fast guarantee instead.

## Dependabot

Also adds a `docker` package-ecosystem block to `dependabot.yml` (grouped weekly PR) so the builder `node` tag and the digest-pinned distroless runtime image are kept updated together.

## Verification

- `docker build --build-arg APP_NAME=sveltekit-example-app` completes successfully
- Container serves HTTP 200 and logs `Listening on http://0.0.0.0:3000`, including after the `CMD ["."]` / `main`-field change
- `docker build` with missing or empty `APP_NAME` fails fast with the clear error message
- Pinned digest confirmed to be the multi-arch image index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
