### PR TITLE
chore(ci): pin dependabot node updates below major version 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,5 +28,9 @@ updates:
     groups:
       docker:
         patterns: ['*']
+    # Runtime is pinned to Node 24; never let Dependabot bump past it.
+    ignore:
+      - dependency-name: node
+        versions: ['>=25']
     commit-message:
       prefix: ci(docker)


### PR DESCRIPTION
## Summary
- Node runtime is pinned to 24 (`>= 24.11` per CLAUDE.md); block Dependabot from proposing Node 26+ Docker image bumps for the `docker` group
- Closes #578, which bumped the Dockerfile's node base image from `24.17.0` to `26.4.0` — we don't want to track past major 24

## Test plan
- [x] Config-only change, verified YAML structure matches dependabot schema