### PR TITLE
feat(ci): add docker structure-test lint gate before publish

### DIFF
--- a/.github/workflows/_docker-lint.yml
+++ b/.github/workflows/_docker-lint.yml
@@ -1,0 +1,200 @@
+# =============================================================================
+# Reusable Workflow: Docker Lint — container structure tests (gate before publish)
+# =============================================================================
+# Runs container-structure-test against the per-arch images that
+# `_docker-build-stage.yml` pushed to ECR by digest (untagged). Nothing is
+# rebuilt — the exact bytes are pulled from the registry by digest, resolved
+# from the `digests-*` artifacts uploaded by the build stage (same workflow
+# run), mirroring `_docker-security-scan.yml`.
+#
+# Together with the security scan this job gates publish: `_ecr-publish.yml`
+# only runs when BOTH pass, so a structurally broken image never gets a tag.
+#
+# Config resolution: `apps/<app_slug>/container-structure-test.yaml` wins if it
+# exists, otherwise the repo-root default (`structure_test_config`). This lets
+# an app override the shared expectations without touching the pipeline.
+#
+# Both arches are tested. The config's commandTests execute the container
+# (they verify the `node .` runtime contract), so QEMU is registered to let
+# the arm64 image run on this amd64 runner.
+
+name: _docker-lint
+
+on:
+  workflow_call:
+    inputs:
+      app_slug:
+        description: "Registry-name-safe app identifier used to select this app's digest artifacts (e.g. effect-api-server)"
+        required: true
+        type: string
+      image_name:
+        description: 'Image repository name without registry (e.g. team/service)'
+        required: true
+        type: string
+      structure_test_config:
+        description: 'Fallback container-structure-test config used when the app has no apps/<app_slug>/container-structure-test.yaml'
+        required: false
+        type: string
+        default: 'container-structure-test.yaml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # assume the AWS role via OIDC
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Same ref the build stage checked out (PR head, not the ephemeral
+          # merge ref) so the structure-test config matches the commit the
+          # image bytes were actually built from.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ vars.AWS_GHA_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      # Resolve this app's per-arch image refs from its digest artifacts. Each
+      # artifact holds a single empty file named after the digest hex (no
+      # sha256: prefix). Downloaded by exact name (one per platform, mirroring
+      # the build matrix) rather than a `digests-<app>-*` pattern: under a
+      # matrix, an app slug that is a prefix of a sibling's (e.g. `api` and
+      # `api-server`) would make the pattern match the sibling's artifacts too.
+      - name: Download amd64 digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests/digests-${{ inputs.app_slug }}-linux-amd64
+          name: digests-${{ inputs.app_slug }}-linux-amd64
+
+      - name: Download arm64 digest artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests/digests-${{ inputs.app_slug }}-linux-arm64
+          name: digests-${{ inputs.app_slug }}-linux-arm64
+
+      - name: Resolve per-arch image refs
+        env:
+          # Via env, not inline expansion: app_slug is a directory basename and
+          # image_name comes from a repo-authored deploy.json, so neither must
+          # reach the shell as code.
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_NAME: ${{ inputs.image_name }}
+          APP_SLUG: ${{ inputs.app_slug }}
+        run: |
+          set -euo pipefail
+          repo="${REGISTRY}/${IMAGE_NAME}"
+          amd64="$(basename "$(ls "/tmp/digests/digests-${APP_SLUG}-linux-amd64"/*)")"
+          arm64="$(basename "$(ls "/tmp/digests/digests-${APP_SLUG}-linux-arm64"/*)")"
+          {
+            echo "REPO=${repo}"
+            echo "AMD64_REF=${repo}@sha256:${amd64}"
+            echo "ARM64_REF=${repo}@sha256:${arm64}"
+          } >> "$GITHUB_ENV"
+
+      # Per-app config wins over the repo-root fallback so apps with different
+      # runtime layouts (entrypoint path, ports, users) can assert their own
+      # structure without loosening the shared default.
+      - name: Resolve structure-test config
+        env:
+          # Via env, not inline expansion: both paths are repo-authored text
+          # and must not reach the shell as code.
+          APP_SLUG: ${{ inputs.app_slug }}
+          FALLBACK_CONFIG: ${{ inputs.structure_test_config }}
+        run: |
+          set -euo pipefail
+          app_config="apps/${APP_SLUG}/container-structure-test.yaml"
+          if [[ -f "$app_config" ]]; then
+            config="$app_config"
+          elif [[ -f "$FALLBACK_CONFIG" ]]; then
+            config="$FALLBACK_CONFIG"
+          else
+            echo "::error::No structure-test config found (looked for ${app_config} and ${FALLBACK_CONFIG})."
+            exit 1
+          fi
+          echo "Using structure-test config: ${config}"
+          echo "STRUCTURE_TEST_CONFIG=${config}" >> "$GITHUB_ENV"
+
+      - name: Install container-structure-test
+        env:
+          CST_VERSION: v1.22.1
+          CST_SHA256: fa35e89512a8978585f76cf41397956d2e3a30c62c2ad3fb857b1597074d14ca
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 \
+            "https://github.com/GoogleContainerTools/container-structure-test/releases/download/${CST_VERSION}/container-structure-test-linux-amd64" \
+            --output container-structure-test
+          echo "${CST_SHA256}  container-structure-test" | sha256sum --check --quiet
+          chmod +x container-structure-test
+          sudo mv container-structure-test /usr/local/bin/container-structure-test
+
+      # QEMU binfmt handlers let the arm64 leg's commandTests execute the
+      # container on this amd64 runner.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      # Each digest is an attestation-bearing OCI index (provenance/SBOM), so
+      # pull with an explicit --platform to select the image child.
+      - name: Pull per-arch images
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "$AMD64_REF"
+          docker pull --platform linux/arm64 "$ARM64_REF"
+
+      - name: Run container structure tests (amd64)
+        id: cst-amd64
+        run: |
+          container-structure-test test --image "$AMD64_REF" --config "$STRUCTURE_TEST_CONFIG"
+        continue-on-error: true
+
+      - name: Run container structure tests (arm64)
+        id: cst-arm64
+        run: |
+          container-structure-test test --image "$ARM64_REF" --config "$STRUCTURE_TEST_CONFIG"
+        continue-on-error: true
+
+      - name: Gate decision
+        run: |
+          AMD64="${{ steps.cst-amd64.outcome }}"
+          ARM64="${{ steps.cst-arm64.outcome }}"
+
+          if [[ "$AMD64" == "success" && "$ARM64" == "success" ]]; then
+            PASSED=true
+          else
+            PASSED=false
+          fi
+
+          icon() { [[ "$1" == "success" ]] && echo "✅ pass" || echo "❌ fail"; }
+
+          {
+            echo "### Docker structure tests"
+            echo ""
+            echo "**Tested repo:** \`${REPO}\`"
+            echo "**Config:** \`${STRUCTURE_TEST_CONFIG}\`"
+            echo ""
+            echo "| Test | Result |"
+            echo "| --- | --- |"
+            echo "| Structure tests (amd64) | $(icon "$AMD64") |"
+            echo "| Structure tests (arm64) | $(icon "$ARM64") |"
+            echo ""
+            if [[ "$PASSED" == "true" ]]; then
+              echo "**Gate:** ✅ passed — image is eligible for publish"
+            else
+              echo "**Gate:** ❌ failed — image will NOT be published"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$PASSED" == "true" ]]; then
+            echo "::notice::Structure tests passed — image is eligible for publish"
+          else
+            echo "::error::Structure tests failed — image will NOT be published"
+            exit 1
+          fi

--- a/.github/workflows/_ecr-publish.yml
+++ b/.github/workflows/_ecr-publish.yml
@@ -1,7 +1,8 @@
 # =============================================================================
 # Reusable Workflow: Publish multi-arch image to ECR (post-gate)
 # =============================================================================
-# Runs ONLY after the security scan gate has passed. Stitches the per-arch
+# Runs ONLY after both pre-publish gates (security scan + structure-test lint)
+# have passed. Stitches the per-arch
 # digests (pushed untagged by the build stage) into a single multi-arch manifest
 # and applies the human-facing tags — this is the ONLY place tags are applied,
 # so an untagged/unverified image can never masquerade as a published one.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,8 +63,8 @@ jobs:
   # Skipped for PRs from forks: fork runs get a read-only token (id-token: write
   # is refused) and no repository secrets/vars, so the AWS OIDC steps would
   # hard-fail and block the merge via ci-cd-passed. Skipping here cascades to
-  # docker-scan and docker-publish; ci-cd-passed treats skips as passing. The
-  # full build/scan/publish still runs on the push to main after merge.
+  # docker-scan, docker-lint, and docker-publish; ci-cd-passed treats skips as
+  # passing. The full build/scan/publish still runs on the push to main after merge.
   docker-build:
     needs: [deploy-matrix]
     if: >-
@@ -109,11 +109,33 @@ jobs:
       app_slug: ${{ matrix.target.app_name }}
       image_name: ${{ matrix.target.image_name }}
 
-  # Only reached when the gate passes for every app: tag each multi-arch
-  # manifest and attest.
+  # Structure-test gate: runs in parallel with docker-scan against the same
+  # per-arch digests. Same all-or-nothing aggregation as the scan gate: any
+  # app's lint failure fails docker-lint and skips docker-publish for every app.
+  docker-lint:
+    needs: [deploy-matrix, docker-build]
+    if: needs.deploy-matrix.outputs.has_apps == 'true'
+    name: docker-lint (${{ matrix.target.app_name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.deploy-matrix.outputs.apps) }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/_docker-lint.yml
+    with:
+      app_slug: ${{ matrix.target.app_name }}
+      image_name: ${{ matrix.target.image_name }}
+
+  # Only reached when BOTH gates (scan + lint) pass for every app: tag each
+  # multi-arch manifest and attest.
   docker-publish:
-    needs: [deploy-matrix, docker-scan]
-    if: needs.deploy-matrix.outputs.has_apps == 'true' && needs.docker-scan.result == 'success'
+    needs: [deploy-matrix, docker-scan, docker-lint]
+    if: >-
+      needs.deploy-matrix.outputs.has_apps == 'true' &&
+      needs.docker-scan.result == 'success' &&
+      needs.docker-lint.result == 'success'
     name: docker-publish (${{ matrix.target.app_name }})
     strategy:
       fail-fast: false
@@ -135,7 +157,15 @@ jobs:
   ci-cd-passed:
     if: always() # Ensures this job ALWAYS runs to report status
     needs:
-      [compute-affected, code-quality, deploy-matrix, docker-build, docker-scan, docker-publish]
+      [
+        compute-affected,
+        code-quality,
+        deploy-matrix,
+        docker-build,
+        docker-scan,
+        docker-lint,
+        docker-publish,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -1,0 +1,56 @@
+# =============================================================================
+# Container Structure Tests
+# https://github.com/GoogleContainerTools/container-structure-test
+#
+# Validates the Docker image meets structural requirements before publishing.
+# This is the repo-wide default used by _docker-lint.yml; it asserts only the
+# invariants every image built by the vite-generic Dockerfile must satisfy.
+# An app needing different assertions provides its own
+# apps/<app>/container-structure-test.yaml, which takes precedence.
+# =============================================================================
+
+schemaVersion: '2.0.0'
+
+# ---------------------------------------------------------------------------
+# Metadata tests — verify image labels and config
+# ---------------------------------------------------------------------------
+metadataTest:
+  #  exposedPorts: ['8080']
+  #  entrypoint: [] # Customize: e.g., ["/app/entrypoint.sh"]
+  workdir: '/app'
+  envVars:
+    - key: 'NODE_ENV'
+      value: 'production'
+
+# ---------------------------------------------------------------------------
+# File existence tests — verify no sensitive files leaked into the image.
+# Layout-agnostic paths only: app build output lives wherever the app's
+# package.json `main`/`files` say, so per-layout paths don't belong here.
+# ---------------------------------------------------------------------------
+fileExistenceTests:
+  - name: 'No .env file leaked into image'
+    path: '/app/.env'
+    shouldExist: false
+
+  - name: 'No .git directory in image'
+    path: '/app/.git'
+    shouldExist: false
+
+# ---------------------------------------------------------------------------
+# Command tests — verify the runtime contract of the vite-generic Dockerfile:
+# CMD ["."] means `node .` must resolve the app's package.json `main` to a
+# file that was actually packed. Testing the invariant instead of a hardcoded
+# entry path keeps this config valid for every app, and executing node also
+# proves the distroless runtime binary works on each architecture.
+# The distroless image has no shell, so commands must be invoked directly.
+# ---------------------------------------------------------------------------
+commandTests:
+  - name: 'package.json main resolves to a packed server entry (node . contract)'
+    command: '/nodejs/bin/node'
+    args:
+      - '-e'
+      - |
+        const p = require('/app/package.json')
+        if (!p.main) throw new Error('package.json must declare main')
+        require('fs').accessSync(require('path').resolve('/app', p.main))
+    exitCode: 0


### PR DESCRIPTION
## Summary

Adds a second pre-publish gate to the docker pipeline: container structure tests, running in parallel with the Trivy security scan. `docker-publish` now requires **both** gates to pass, so a structurally broken image never gets a tag.

### `_docker-lint.yml` (new reusable workflow)

Reworked from a tarball-artifact design into the same digest-based pattern as `_docker-security-scan.yml`:

- Takes `app_slug` + `image_name` (same contract as scan/publish), resolves the per-arch image refs from the build stage's `digests-*` artifacts, and pulls the exact bytes from ECR by digest — nothing is rebuilt.
- Tests **both arches**. QEMU is registered so the arm64 image's commandTests can execute on the amd64 runner.
- Per-app config precedence: `apps/<app_slug>/container-structure-test.yaml` wins over the repo-root default.
- Hardened to repo conventions: `container-structure-test` is version-pinned (v1.22.1) with sha256 verification instead of curl-ing `latest`; all actions SHA-pinned; repo-authored values reach the shell via `env`, never inline expansion.
- `continue-on-error` legs feed a gate-decision step that writes a pass/fail table to the step summary, mirroring the scan gate.

### `container-structure-test.yaml` (repo-root default)

Asserts the vite-generic Dockerfile's actual runtime contract instead of a hardcoded SvelteKit layout:

- A commandTest runs `/nodejs/bin/node -e` to verify `package.json` `main` resolves to a packed file — exactly what `CMD ["."]` needs at runtime, valid for any app. Also proves the distroless node binary executes per arch.
- Leak checks generalized to layout-agnostic paths (`/app/.env`, `/app/.git`).
- Keeps the `NODE_ENV=production` / workdir metadata assertions.

### `ci-cd.yml` wiring

- New `docker-lint` matrix job parallel to `docker-scan` (same `needs: docker-build`, same all-or-nothing aggregation, fork-PR skips cascade identically).
- `docker-publish` requires `success` from both `docker-scan` and `docker-lint`.
- `docker-lint` added to `ci-cd-passed`'s `needs` so its result rolls into the required check.

## Notes for review

- The smoke test from the original workflow is deliberately **not** included here — an opt-in per-app design is prepared as a fast-follow PR.
- First real run to watch: the arm64 commandTest executes under QEMU emulation (trivial script, well within the 15-min job timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)