### PR TITLE
feat(ci): add opt-in http smoke test to docker lint gate

### DIFF
--- a/.github/workflows/_docker-lint.yml
+++ b/.github/workflows/_docker-lint.yml
@@ -17,6 +17,16 @@
 # Both arches are tested. The config's commandTests execute the container
 # (they verify the `node .` runtime contract), so QEMU is registered to let
 # the arm64 image run on this amd64 runner.
+#
+# Smoke test (opt-in): when `apps/<app_slug>/smoke-test.json` exists, the amd64
+# image is booted and must answer HTTP on the configured path — any status
+# counts, since a response at all proves the entrypoint, boot-time config, and
+# listener work. No config file means the step is skipped, not failed. amd64
+# only: booting a full server under QEMU is slow and timing-flaky, and the
+# structure commandTests already prove the arm64 image executes.
+# The config is repo-committed, so its env values must be dummies (an app that
+# validates e.g. a DB connection string at boot gets a syntactically valid
+# placeholder — lazy connection pools mean the server still boots and serves).
 
 name: _docker-lint
 
@@ -161,21 +171,91 @@ jobs:
           container-structure-test test --image "$ARM64_REF" --config "$STRUCTURE_TEST_CONFIG"
         continue-on-error: true
 
+      # Smoke test is opt-in per app: no smoke-test.json means the step below
+      # is skipped and the gate treats it as passing.
+      - name: Resolve smoke-test config
+        id: smoke-config
+        env:
+          # Via env, not inline expansion: app_slug is a directory basename and
+          # must not reach the shell as code.
+          APP_SLUG: ${{ inputs.app_slug }}
+        run: |
+          set -euo pipefail
+          config="apps/${APP_SLUG}/smoke-test.json"
+          if [[ ! -f "$config" ]]; then
+            echo "::notice::No ${config} — smoke test skipped (opt-in)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fail loud on a malformed opt-in rather than silently skipping it.
+          if ! jq -e . "$config" > /dev/null 2>&1; then
+            echo "::error file=${config}::smoke-test.json is not valid JSON."
+            exit 1
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "SMOKE_CONFIG=${config}" >> "$GITHUB_ENV"
+
+      - name: Run smoke test (amd64)
+        id: smoke
+        if: steps.smoke-config.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          container_port="$(jq -r '.containerPort // 3000' "$SMOKE_CONFIG")"
+          http_path="$(jq -r '.path // "/"' "$SMOKE_CONFIG")"
+          timeout="$(jq -r '.startupTimeoutSeconds // 30' "$SMOKE_CONFIG")"
+          # Env via --env-file, not shell-built --env flags: values never pass
+          # through shell parsing.
+          jq -r '.env // {} | to_entries[] | "\(.key)=\(.value)"' "$SMOKE_CONFIG" > /tmp/smoke.env
+
+          trap 'docker rm -f smoke-test >/dev/null 2>&1 || true' EXIT
+          docker run -d --name smoke-test \
+            -p "127.0.0.1::${container_port}" \
+            --env-file /tmp/smoke.env \
+            "$AMD64_REF"
+          # Ephemeral host port — no collisions with anything else on the runner.
+          addr="$(docker port smoke-test "${container_port}/tcp" | head -n 1)"
+
+          # Poll until the server answers HTTP (any status proves boot) instead
+          # of sleeping a fixed startup budget; bail early if the container dies.
+          deadline=$((SECONDS + timeout))
+          until status="$(curl -s -o /dev/null --max-time 5 -w '%{http_code}' "http://${addr}${http_path}")"; do
+            if [[ "$(docker inspect -f '{{.State.Running}}' smoke-test)" != "true" ]]; then
+              echo "::error::Container exited before responding on ${http_path}"
+              docker logs smoke-test
+              exit 1
+            fi
+            if (( SECONDS >= deadline )); then
+              echo "::error::No HTTP response on ${http_path} within ${timeout}s"
+              docker logs smoke-test
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Smoke test passed: HTTP ${status} from ${http_path}"
+        continue-on-error: true
+
       - name: Gate decision
         run: |
           AMD64="${{ steps.cst-amd64.outcome }}"
           ARM64="${{ steps.cst-arm64.outcome }}"
+          SMOKE="${{ steps.smoke.outcome }}" # 'skipped' when the app has no smoke-test.json
 
-          if [[ "$AMD64" == "success" && "$ARM64" == "success" ]]; then
+          if [[ "$AMD64" == "success" && "$ARM64" == "success" && "$SMOKE" != "failure" ]]; then
             PASSED=true
           else
             PASSED=false
           fi
 
-          icon() { [[ "$1" == "success" ]] && echo "✅ pass" || echo "❌ fail"; }
+          icon() {
+            case "$1" in
+              success) echo "✅ pass" ;;
+              skipped) echo "⏭️ skipped (opt-in)" ;;
+              *) echo "❌ fail" ;;
+            esac
+          }
 
           {
-            echo "### Docker structure tests"
+            echo "### Docker image lint"
             echo ""
             echo "**Tested repo:** \`${REPO}\`"
             echo "**Config:** \`${STRUCTURE_TEST_CONFIG}\`"
@@ -184,6 +264,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Structure tests (amd64) | $(icon "$AMD64") |"
             echo "| Structure tests (arm64) | $(icon "$ARM64") |"
+            echo "| Smoke test (amd64) | $(icon "$SMOKE") |"
             echo ""
             if [[ "$PASSED" == "true" ]]; then
               echo "**Gate:** ✅ passed — image is eligible for publish"
@@ -193,8 +274,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$PASSED" == "true" ]]; then
-            echo "::notice::Structure tests passed — image is eligible for publish"
+            echo "::notice::Image lint passed — image is eligible for publish"
           else
-            echo "::error::Structure tests failed — image will NOT be published"
+            echo "::error::Image lint failed — image will NOT be published"
             exit 1
           fi

--- a/.github/workflows/_docker-lint.yml
+++ b/.github/workflows/_docker-lint.yml
@@ -159,16 +159,19 @@ jobs:
           docker pull --platform linux/amd64 "$AMD64_REF"
           docker pull --platform linux/arm64 "$ARM64_REF"
 
+      # --platform must match each image: c-s-t defaults it to the host arch
+      # and passes it through to container creation, so without it the daemon
+      # refuses to create commandTest containers from the arm64 image.
       - name: Run container structure tests (amd64)
         id: cst-amd64
         run: |
-          container-structure-test test --image "$AMD64_REF" --config "$STRUCTURE_TEST_CONFIG"
+          container-structure-test test --image "$AMD64_REF" --platform linux/amd64 --config "$STRUCTURE_TEST_CONFIG"
         continue-on-error: true
 
       - name: Run container structure tests (arm64)
         id: cst-arm64
         run: |
-          container-structure-test test --image "$ARM64_REF" --config "$STRUCTURE_TEST_CONFIG"
+          container-structure-test test --image "$ARM64_REF" --platform linux/arm64 --config "$STRUCTURE_TEST_CONFIG"
         continue-on-error: true
 
       # Smoke test is opt-in per app: no smoke-test.json means the step below

--- a/apps/effect-api-server/smoke-test.json
+++ b/apps/effect-api-server/smoke-test.json
@@ -1,0 +1,8 @@
+{
+  "containerPort": 3000,
+  "path": "/",
+  "startupTimeoutSeconds": 30,
+  "env": {
+    "DB_CONNECTION_STRING": "postgres://smoke:smoke@localhost:5432/smoke"
+  }
+}


### PR DESCRIPTION
## Summary

Fast-follow to #582: adds an opt-in HTTP smoke test to the `_docker-lint.yml` gate. The amd64 image is booted and must answer HTTP on a configured path before the image can be published — proving the entrypoint, boot-time config, and listener actually work.

### How it works

- **Opt-in per app:** the smoke test runs only when `apps/<app_slug>/smoke-test.json` exists; no file means the step is skipped (and the gate treats skipped as passing). Malformed JSON fails loudly rather than silently skipping.
- **Config shape** (repo-committed, dummy values only — never secrets):
  ```json
  {
    "containerPort": 3000,
    "path": "/",
    "startupTimeoutSeconds": 30,
    "env": { "KEY": "value" }
  }
  ```
- **Assertion is "any HTTP response":** no app exposes a health endpoint yet, so a response at all is the strongest generic signal — it catches broken entrypoints, crash-on-boot, and missing-env regressions. Tightening to 2xx is a follow-up once a real `/health` route exists.
- **amd64 only:** booting a full server under QEMU is slow and timing-flaky; the structure commandTests from #582 already prove the arm64 image executes.

### Mechanics

- Polls the endpoint until it responds instead of sleeping a fixed startup budget; bails early with `docker logs` if the container exits.
- Env values go through `--env-file`, never shell parsing; config paths/values are read via `jq` in-shell (no inline `${{ }}` expansion).
- `trap`-based container cleanup; ephemeral localhost host port (no collisions).
- Gate summary table gains a third row: `Smoke test (amd64)` — pass / fail / skipped (opt-in).

### First opt-in: `effect-api-server`

`apps/effect-api-server/smoke-test.json` supplies a dummy `DB_CONNECTION_STRING` — the config is validated at boot (`Config.redacted`, no default) but pg pools connect lazily, so the server boots and serves without a database.

## Notes for review

- This PR touches `apps/effect-api-server/`, so the full build → lint/scan → publish chain runs, giving the smoke test its first real end-to-end exercise (the workflow-only #582 skipped the docker chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)